### PR TITLE
Kommentar in UmsatzEditorControl bearbeitbar

### DIFF
--- a/src/de/open4me/depot/gui/control/UmsatzEditorControl.java
+++ b/src/de/open4me/depot/gui/control/UmsatzEditorControl.java
@@ -27,6 +27,7 @@ import de.willuhn.jameica.gui.input.DateInput;
 import de.willuhn.jameica.gui.input.DecimalInput;
 import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.SelectInput;
+import de.willuhn.jameica.gui.input.TextAreaInput;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.hbci.rmi.Konto;
 import de.willuhn.util.ApplicationException;
@@ -47,6 +48,7 @@ public class UmsatzEditorControl extends AbstractControl
 	private AbstractInput transaktionskosten;
 	private DecimalInput steuern;
 	private Umsatz umsatz = null;
+	private Input kommentar;
 
 	public UmsatzEditorControl(AbstractView view) throws Exception {
 		super(view);
@@ -63,6 +65,7 @@ public class UmsatzEditorControl extends AbstractControl
 		getSteuern().setValue((umsatz.getSteuern() != null) ? umsatz.getSteuern() : 0.0d);
 		getTransaktionskosten().setValue((umsatz.getTransaktionsgebuehren() != null) ? umsatz.getTransaktionsgebuehren()  : 0.0d);
 		getKurswert().setValue(Math.abs(umsatz.getKosten().doubleValue()));
+		getKommentar().setValue(umsatz.getKommentar());
 		
 		String id = umsatz.getWPid().toString();
 		boolean found = false;
@@ -105,7 +108,7 @@ public class UmsatzEditorControl extends AbstractControl
 		if (betrag != null)
 			return betrag;
 		double d = Double.NaN;
-		betrag = new DecimalInput(d, new VarDecimalFormat(5));
+		betrag = new DecimalInput(d, new VarDecimalFormat(2, 3));
 		betrag.setMandatory(true);
 		betrag.addListener(new Listener() {
 
@@ -168,7 +171,7 @@ public class UmsatzEditorControl extends AbstractControl
 		if (einzelkurs != null)
 			return einzelkurs;
 		double d = Double.NaN;
-		einzelkurs = new DecimalInput(d, new VarDecimalFormat(5));
+		einzelkurs = new DecimalInput(d, new VarDecimalFormat(2, 3));
 		einzelkurs.setMandatory(true);
 		einzelkurs.addListener(new Listener() {
 
@@ -241,7 +244,6 @@ public class UmsatzEditorControl extends AbstractControl
 		}
 		if (umsatz == null) {
 			umsatz = (Umsatz) Settings.getDBService().createObject(Umsatz.class,null);
-			umsatz.setKommentar("");
 			umsatz.setBuchungsinformationen("");
 			umsatz.setOrderid("" + (((GenericObjectSQL) getWertpapiere().getValue()).getID() + getAktionAuswahl().getValue().toString() +
 						getAnzahl().getValue().toString() + getEinzelkurs().getValue().toString() + "EUR" + getDate().getValue()
@@ -261,6 +263,7 @@ public class UmsatzEditorControl extends AbstractControl
 		umsatz.setBuchungsdatum((Date) getDate().getValue());
 		umsatz.setSteuern(new BigDecimal((Double) getSteuern().getValue()));
 		umsatz.setTransaktionsgebuehren(new BigDecimal((Double) getTransaktionskosten().getValue()));
+		umsatz.setKommentar((String)getKommentar().getValue());
 		umsatz.store();
 
 	}
@@ -286,17 +289,26 @@ public class UmsatzEditorControl extends AbstractControl
 		if (gesamt != null)
 			return gesamt;
 		double d = Double.NaN;
-		gesamt = new DecimalInput(d, new VarDecimalFormat(5));
+		gesamt = new DecimalInput(d, new VarDecimalFormat(2));
 		gesamt.setMandatory(true);
 		gesamt.setEnabled(false);
 		return gesamt;
+	}
+	
+	public Input getKommentar() {
+		if (kommentar != null)
+			return kommentar;
+		kommentar = new TextAreaInput(null, 2000);
+		((TextAreaInput)kommentar).setHeight(50);
+		kommentar.setMandatory(false);
+		return kommentar;
 	}
 
 	public Input getKurswert() {
 		if (kurswert != null)
 			return kurswert;
 		double d = Double.NaN;
-		kurswert = new DecimalInput(d, new VarDecimalFormat(5));
+		kurswert = new DecimalInput(d, new VarDecimalFormat(2, 3));
 		kurswert.setMandatory(true);
 		return kurswert;
 	}
@@ -305,7 +317,7 @@ public class UmsatzEditorControl extends AbstractControl
 		if (transaktionskosten != null)
 			return transaktionskosten;
 		double d = Double.valueOf("0");
-		transaktionskosten = new DecimalInput(d, new VarDecimalFormat(5));
+		transaktionskosten = new DecimalInput(d, new VarDecimalFormat(2, 3));
 		transaktionskosten.setMandatory(true);
 		transaktionskosten.addListener(new Listener() {
 
@@ -336,7 +348,7 @@ public class UmsatzEditorControl extends AbstractControl
 		if (steuern != null)
 			return steuern;
 		double d = Double.valueOf("0");
-		steuern = new DecimalInput(d, new VarDecimalFormat(5));
+		steuern = new DecimalInput(d, new VarDecimalFormat(2, 3));
 		steuern.setMandatory(true);
 		steuern.addListener(new Listener() {
 

--- a/src/de/open4me/depot/gui/view/UmsatzEditorView.java
+++ b/src/de/open4me/depot/gui/view/UmsatzEditorView.java
@@ -36,6 +36,7 @@ public class UmsatzEditorView extends AbstractView {
 		left.addLabelPair("Datum", control.getDate());
 		left.addLabelPair("Konto", control.getKonto());
 		left.addLabelPair("Aktion", control.getAktionAuswahl());
+		left.addLabelPair("Kommentar", control.getKommentar());
 
 		Container right = new SimpleContainer(columns.getComposite());
 

--- a/src/de/open4me/depot/tools/VarDecimalFormat.java
+++ b/src/de/open4me/depot/tools/VarDecimalFormat.java
@@ -4,22 +4,32 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.FieldPosition;
 
+import org.apache.commons.lang3.StringUtils;
+
 import de.willuhn.jameica.system.Application;
 
 public class VarDecimalFormat extends DecimalFormat
 {
 	
 	public static String nullen(int nachkommastellen) {
-		String out = "";
-		for (int i = 0;  i < nachkommastellen; i++) {
-			out += "0";
-		}
-		return out;
+		return StringUtils.repeat('0', nachkommastellen);
 	}
+	
 	int nachkommastellen;
 	public VarDecimalFormat(int nachkommastellen)
 	{
-		super("###,###,##0." + nullen(nachkommastellen),new DecimalFormatSymbols(Application.getConfig().getLocale()));
+		this(nachkommastellen, 0);
+	}
+	
+	/**
+	 * Formatiert einen Wert mit x fixen Nachkommastellen, die Notfalls durch Nullen aufgefüllt werden.
+	 * Sollte der Wert genauer sein und mehr Nachkommastellen enthalten, so werden bis zu {@code extranachkommastellen} viele zusätzlich angezeigt. 
+	 * @param nachkommastellen
+	 * @param extranachkommastellen
+	 */
+	public VarDecimalFormat(int nachkommastellen, int extranachkommastellen)
+	{
+		super("###,###,##0." + nullen(nachkommastellen) + StringUtils.repeat('#', extranachkommastellen),new DecimalFormatSymbols(Application.getConfig().getLocale()));
 		this.nachkommastellen = nachkommastellen;
 		setGroupingUsed(true);
 	}


### PR DESCRIPTION
Kommentar in UmsatzEditorControl bearbeitbar.

Zusätzlich Wertfelder so formatiert, dass nur noch 2 Nachkommastellen angezeigt werden, falls sie Nullen sind.
Ich fände es schöner, wenn Zahlen rechtsbündig angeordnet wären, aber das ist Geschmackssache.