### PR TITLE
Chart Farben angepasst

### DIFF
--- a/src/de/open4me/depot/gui/control/BestandPieChartControl.java
+++ b/src/de/open4me/depot/gui/control/BestandPieChartControl.java
@@ -19,6 +19,7 @@ import org.jfree.data.general.PieDataset;
 import org.jfree.experimental.chart.swt.ChartComposite;
 import org.jfree.experimental.swt.SWTUtils;
 import org.jfree.util.Rotation;
+import org.jfree.util.SortOrder;
 
 import de.open4me.depot.gui.DatumsSlider;
 import de.open4me.depot.sql.GenericObjectSQL;
@@ -50,7 +51,7 @@ public class BestandPieChartControl implements Listener
 		chart.getLegend().setItemFont(font.deriveFont(9.0f));
 		PiePlot3D plot = (PiePlot3D) chart.getPlot();
 		plot.setBackgroundAlpha(0);
-		plot.setStartAngle(290);
+		plot.setStartAngle(270);
 		plot.setDirection(Rotation.CLOCKWISE);
 		plot.setForegroundAlpha(0.8f);
 		plot.setOutlineVisible(false);
@@ -103,6 +104,7 @@ public class BestandPieChartControl implements Listener
 					
 					dataset.setValue((String) x.getAttribute("wertpapiername"), wert);
 				}
+				dataset.sortByValues(SortOrder.DESCENDING);
 			} catch (Exception e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();

--- a/src/de/open4me/depot/gui/control/WertpapiereDatenControl.java
+++ b/src/de/open4me/depot/gui/control/WertpapiereDatenControl.java
@@ -1,5 +1,6 @@
 package de.open4me.depot.gui.control;
 
+import java.awt.Color;
 import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
 import java.math.BigDecimal;
@@ -26,6 +27,7 @@ import org.jfree.chart.annotations.XYTextAnnotation;
 import org.jfree.chart.renderer.xy.XYItemRenderer;
 import org.jfree.experimental.chart.swt.ChartComposite;
 import org.jfree.ui.Layer;
+import org.jfree.ui.RectangleInsets;
 
 import de.open4me.depot.Settings;
 import de.open4me.depot.abruf.utils.Utils;
@@ -274,6 +276,11 @@ public class WertpapiereDatenControl {
 				chart = ChartFactory.createTimeSeriesChart(
 						"",  "Datum",
 						"Kurs", data, true, true, false);
+				chart.getXYPlot().setBackgroundPaint(Color.WHITE);
+				chart.getXYPlot().setOutlineVisible(false);
+				chart.getXYPlot().setAxisOffset(RectangleInsets.ZERO_INSETS);
+				chart.getXYPlot().setDomainGridlinePaint(Color.LIGHT_GRAY);
+				chart.getXYPlot().setRangeGridlinePaint(Color.LIGHT_GRAY);
 				renderer = chart.getXYPlot().getRenderer();
 				Rectangle maxSize = GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
 				new ChartComposite(getComposite(), SWT.NONE, chart, 

--- a/src/de/open4me/depot/gui/control/WertpapiereDatenControl.java
+++ b/src/de/open4me/depot/gui/control/WertpapiereDatenControl.java
@@ -1,5 +1,7 @@
 package de.open4me.depot.gui.control;
 
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.rmi.RemoteException;
@@ -273,7 +275,21 @@ public class WertpapiereDatenControl {
 						"",  "Datum",
 						"Kurs", data, true, true, false);
 				renderer = chart.getXYPlot().getRenderer();
-				new ChartComposite(getComposite(), SWT.NONE, chart, true);
+				Rectangle maxSize = GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
+				new ChartComposite(getComposite(), SWT.NONE, chart, 
+						ChartComposite.DEFAULT_WIDTH,
+						ChartComposite.DEFAULT_HEIGHT,
+						ChartComposite.DEFAULT_MINIMUM_DRAW_WIDTH,
+						ChartComposite.DEFAULT_MINIMUM_DRAW_HEIGHT,
+						maxSize.width, // ChartComposite.DEFAULT_MAXIMUM_DRAW_WIDTH,
+						maxSize.height, // ChartComposite.DEFAULT_MAXIMUM_DRAW_HEIGHT,
+		                true,  // useBuffer
+		                true,  // properties
+		                true,  // save
+		                true,  // print
+		                true,  // zoom
+		                true   // tooltips
+	                );
 			}
 			
 			String lastSelection = "";


### PR DESCRIPTION
Chart Farben an Hibiscus angepasst (weißer Hintergrund mit grauen Linien, statt dunkelgrauem Hintergrund).

Bei dem Wertpapier-Chart maximumDrawWidth und maximumDrawHeight auf Bildschirmgröße gesetzt. Dadurch wird eine Verzerrung des Textes verhindert.

Bestands-Chart nach Werten sortiert. Vorher erschienen die PieChart-Werte mehr oder weniger zufällig sortiert. Zudem Startwinkel auf 270 Grad gesetzt, was unten entspricht.