### PR TITLE
Berücksichtigung von Auslieferungen bei parseDepotUmsatz

### DIFF
--- a/src/de/open4me/depot/hbcijobs/HBCIDepotUmsatzJob.java
+++ b/src/de/open4me/depot/hbcijobs/HBCIDepotUmsatzJob.java
@@ -126,6 +126,7 @@ public class HBCIDepotUmsatzJob extends AbstractHBCIJob
 		for (FinancialInstrument i : entries.instruments) {
 			for (Transaction t : i.transactions) {
 				// Einlage Betrag = null; transaction_indicator: 2: Kapitalmassnahme; richtung: 2 Erhalt; bezahlung 2: frei
+				// Auslieferung Betrag = null; transaction_indicator: 2: Corporate Action; richtung: 1 Lieferung; bezahlung 2: frei
 				// Kauf Betrag = -9999, transaction_indicator: : 1: Settlement/Clearing; richtung: 2 Erhalt; bezahlung 2: frei
 				// Verkauf Betrag = 9999, transaction_indicator :1: Settlement/Clearing; richtung 1: Lieferung bezahlung 2: frei
 
@@ -141,6 +142,9 @@ public class HBCIDepotUmsatzJob extends AbstractHBCIJob
 				if (t.transaction_indicator == Transaction.INDICATOR_CORPORATE_ACTION 
 						&& t.richtung == Transaction.RICHTUNG_ERHALT) {
 					aktion = DepotAktion.EINBUCHUNG.internal();
+				} else if (t.transaction_indicator == Transaction.INDICATOR_CORPORATE_ACTION 
+						&& t.richtung == Transaction.RICHTUNG_LIEFERUNG) {
+					aktion = DepotAktion.AUSBUCHUNG.internal();
 				} else if (t.transaction_indicator == Transaction.INDICATOR_SETTLEMENT_CLEARING 
 						&& t.richtung == Transaction.RICHTUNG_ERHALT) {
 					aktion = DepotAktion.KAUF.internal();


### PR DESCRIPTION
Beim Parsen von Depot-Umsätzen waren Auslieferungen nicht berücksichtigt. Hier ein Beispiel der Transaktionsdaten:

```
Transaction 0:
kundenreferenz: NONREF
anzahl: 200  Stück
betrag: null
stueckzinsen: null
stueckzins_tage: 0
transaction_indicator: 2: Corporate Action
richtung: 1: Lieferung
bezahlung: 2: frei
ccp_eligibility: false
datum: Fri Mar 26 00:00:00 CET 2021
datum_valuta: Fri Mar 26 00:00:00 CET 2021
storno: false
gegenpartei: null
freitext_details: Lastschrift
000000000000000
```