### PR TITLE
Name der Xetra-Liste hat sich geändert

### DIFF
--- a/src/de/open4me/depot/gui/action/DownloadXetraListeAction.java
+++ b/src/de/open4me/depot/gui/action/DownloadXetraListeAction.java
@@ -36,7 +36,7 @@ public class DownloadXetraListeAction implements Action
 
 				TransportService ts = Application.getBootLoader().getBootable(TransportService.class);
 				try {
-					t = ts.getTransport(new URL("https://www.xetra.com/resource/blob/1528/66a7b188aa69b3b39277e30166ae4b38/data/t7-xetr-allTradableInstruments.csv"));
+					t = ts.getTransport(new URL("https://www.cashmarket.deutsche-boerse.com/resource/blob/1528/66a7b188aa69b3b39277e30166ae4b38/data/t7-xetr-allTradableInstruments.csv"));
 					if (!t.exists()) {
 						Application.getMessagingFactory().sendMessage(new StatusBarMessage(Application.getI18n().tr("Datei nicht gefunden! Keine Internetverbindung?"),StatusBarMessage.TYPE_ERROR));
 						return;


### PR DESCRIPTION
scheinbar laufen auf dem Namen zwei URL's und das SSL-Zertifikat lautet auf www.cashmarket.deutsche-boerse.com -- damit kommt der Downloader nicht klar