### PR TITLE
CVS import crashes when import items will render the stage 2 of import dialog

### DIFF
--- a/src/de/open4me/depot/gui/dialogs/CSVImportStage1.java
+++ b/src/de/open4me/depot/gui/dialogs/CSVImportStage1.java
@@ -33,7 +33,9 @@ import de.willuhn.util.ApplicationException;
 
 @SuppressWarnings("rawtypes")
 public class CSVImportStage1 extends AbstractDialog
-{	  
+{
+	private static final int PREVIEW_ROWS = 500;
+
 	private Composite comp;
 	private LabelInput error;
 	private Button weiterbutton;
@@ -140,7 +142,11 @@ public class CSVImportStage1 extends AbstractDialog
 			this.getError().setValue("Fehler beim Lesen der Datei:\n" + e.getMessage());
 			enable = false;
 		}
-		TablePart tab = new TablePart(list, null);
+		List<GenericObjectHashMap> preview = list.subList(0, Math.min(PREVIEW_ROWS, list.size()));
+		if (list.size() > preview.size()) {
+			getError().setValue("Die mit X markierten Zeilen werden ignoriert. (Vorschau: " + preview.size() + " von " + list.size() + " Zeilen)");
+		}
+		TablePart tab = new TablePart(preview, null);
 // TODO		tab.addColumn("" + headerline, "_DEPOTVIEWER_IDX");
 		tab.addColumn("", "_DEPOTVIEWER_IGNORE");
 		for (String h : header) {

--- a/src/de/open4me/depot/gui/dialogs/CSVImportStage1.java
+++ b/src/de/open4me/depot/gui/dialogs/CSVImportStage1.java
@@ -34,7 +34,7 @@ import de.willuhn.util.ApplicationException;
 @SuppressWarnings("rawtypes")
 public class CSVImportStage1 extends AbstractDialog
 {
-	private static final int PREVIEW_ROWS = 500;
+	private static final int PREVIEW_ROWS = 100;
 
 	private Composite comp;
 	private LabelInput error;

--- a/src/de/open4me/depot/gui/dialogs/CSVImportStage2.java
+++ b/src/de/open4me/depot/gui/dialogs/CSVImportStage2.java
@@ -36,7 +36,9 @@ import de.willuhn.util.ApplicationException;
 
 
 public class CSVImportStage2 extends AbstractDialog
-{	  
+{
+	private static final int PREVIEW_ROWS = 500;
+
 	private LabelInput error;
 	private Button weiterbutton;
 	List<GenericObjectHashMap> tablist = new ArrayList<GenericObjectHashMap>();
@@ -190,7 +192,8 @@ public class CSVImportStage2 extends AbstractDialog
 	private void reload() throws RemoteException {
 		getError().setValue("");
 		int fehler = tool.transformiereDaten(tablist);
-		TablePart tab = new TablePart(tablist, null);
+		List<GenericObjectHashMap> preview = tablist.subList(0, Math.min(PREVIEW_ROWS, tablist.size()));
+		TablePart tab = new TablePart(preview, null);
 		for (FeldDefinitionen h : feldDefinitionen) {
 			if (h.getFeldtype().equals(Date.class)) {
 				tab.addColumn(h.getAttr(), h.getAttr(), new DateFormatter(Settings.DATEFORMAT));
@@ -198,11 +201,14 @@ public class CSVImportStage2 extends AbstractDialog
 				tab.addColumn(h.getAttr(), h.getAttr());
 			}
 		}
-		if (fehler == 0) {
-			getError().setValue("");
-		} else {
-			getError().setValue("Fehlerhafte Zellen: " + fehler);
+		String msg = "";
+		if (fehler != 0) {
+			msg = "Fehlerhafte Zellen: " + fehler;
 		}
+		if (tablist.size() > preview.size()) {
+			msg = msg + (msg.isEmpty() ? "" : "\n") + "Vorschau: " + preview.size() + " von " + tablist.size() + " Zeilen";
+		}
+		getError().setValue(msg);
 		weiterbutton.setEnabled(fehler == 0);
 
 		rc.replace(tab);

--- a/src/de/open4me/depot/gui/dialogs/CSVImportStage2.java
+++ b/src/de/open4me/depot/gui/dialogs/CSVImportStage2.java
@@ -37,7 +37,7 @@ import de.willuhn.util.ApplicationException;
 
 public class CSVImportStage2 extends AbstractDialog
 {
-	private static final int PREVIEW_ROWS = 500;
+	private static final int PREVIEW_ROWS = 100;
 
 	private LabelInput error;
 	private Button weiterbutton;

--- a/src/de/open4me/depot/gui/dialogs/CSVImportStage2.java
+++ b/src/de/open4me/depot/gui/dialogs/CSVImportStage2.java
@@ -19,6 +19,7 @@ import de.open4me.depot.tools.io.feldConverter.options.FeldConverterAuswahl;
 import de.open4me.depot.tools.io.feldConverter.options.FeldConverterOption;
 import de.open4me.depot.tools.io.feldConverter.options.FeldConverterText;
 import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
 import de.willuhn.jameica.gui.formatter.DateFormatter;
 import de.willuhn.jameica.gui.input.AbstractInput;
@@ -68,6 +69,12 @@ public class CSVImportStage2 extends AbstractDialog
 	protected void paint(Composite parent) throws Exception
 	{
 		//		controls = new HashMap<FeldDefinitionen, AbstractInput>();
+
+		// Ohne feste Hoehe waechst der Dialog mit der Anzahl der Tabellenzeilen
+		// unbegrenzt (TablePart hat zwar eigene Scrollbalken, aber der Shell
+		// wird per pack() sonst auf die volle Tabellenhoehe aufgezogen).
+		int maxHeight = (int) (GUI.getShell().getMonitor().getBounds().height * 0.9);
+		setSize(SWT.DEFAULT, maxHeight);
 
 		SimpleContainer columns = new SimpleContainer(parent, true, 2);
 		ScrolledContainer left = new ScrolledContainer(columns.getComposite());

--- a/src/de/open4me/depot/tools/io/CSVImportTool.java
+++ b/src/de/open4me/depot/tools/io/CSVImportTool.java
@@ -8,7 +8,6 @@ import java.nio.charset.Charset;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.csv.CSVFormat;
@@ -74,7 +73,7 @@ public class CSVImportTool {
 		boolean isheader = true;
 		header.clear();
 		for(CSVRecord record : parser) {
-			if (nonData(getCsvValues(record))) {
+			if (isEmptyRecord(record)) {
 				continue;
 			}
 			if (isheader) {
@@ -116,13 +115,13 @@ public class CSVImportTool {
 		loadedSkipLines = skipLinesValue;
 	}
 
-	private List<String> getCsvValues(CSVRecord csvRecord) {
-		ArrayList<String> values = new ArrayList<>();
-		for ( String value : csvRecord) {
-			values.add(value);
+	private boolean isEmptyRecord(CSVRecord record) {
+		for (String value : record) {
+			if (value != null && !value.trim().isEmpty()) {
+				return false;
+			}
 		}
-
-		return values;
+		return true;
 	}
 
 	public List<GenericObjectHashMap> getList() {
@@ -177,10 +176,6 @@ public class CSVImportTool {
 			tablist.add(g);
 		}
 		return fehler;
-	}
-
-	private boolean nonData(Collection<?> values) {
-		return values.stream().allMatch(value -> value == null || value.toString().trim().isEmpty());
 	}
 
 	public ArrayList<FeldConverterAuswahl<?>> getCsvOptions() {

--- a/src/de/open4me/depot/tools/io/CSVImportTool.java
+++ b/src/de/open4me/depot/tools/io/CSVImportTool.java
@@ -29,6 +29,10 @@ public class CSVImportTool {
 	private FeldConverterAuswahl<String> trennzeichen = new FeldConverterAuswahl<String>("separator", "Trennzeichen", Arrays.asList(new String[] { ";", ",", "|", "\t" }));
 	private FeldConverterAuswahl<Integer> skipLines = new FeldConverterAuswahl<Integer>("rowheader", "Zeile mit den Spaltennamen", Arrays.asList(new Integer[] { 1, 2, 3, 4, 5, 6, 7, 8, 9,10 }));
 	private File file;
+	private long loadedFileModified = -1;
+	private String loadedCharset;
+	private String loadedTrennzeichen;
+	private Integer loadedSkipLines;
 
 	public CSVImportTool(ArrayList<FeldDefinitionen> fd) {
 		this.feldDefinitionen = fd;
@@ -43,10 +47,22 @@ public class CSVImportTool {
 	}
 
 	public void load() throws IOException {
+		long fileModified = file.lastModified();
+		String charsetValue = charset.getAuswahl();
+		String trennzeichenValue = trennzeichen.getAuswahl();
+		Integer skipLinesValue = skipLines.getAuswahl();
+		if (fileModified == loadedFileModified
+				&& charsetValue.equals(loadedCharset)
+				&& trennzeichenValue.equals(loadedTrennzeichen)
+				&& skipLinesValue.equals(loadedSkipLines)) {
+			// Datei und Einstellungen unverändert, keine erneute Verarbeitung nötig
+			return;
+		}
+
 		header.clear();
 		long counter = 0;
 
-		int headerline = skipLines.getAuswahl() - 1;
+		int headerline = skipLinesValue - 1;
 		FileInputStream is = new FileInputStream(file);
 		InputStreamReader isr = new InputStreamReader(is, Charset.forName(charset.getAuswahl()) );
 		CSVFormat format = CSVFormat.RFC4180
@@ -93,6 +109,11 @@ public class CSVImportTool {
 			list.add(g);
 		}
 		parser.close();
+
+		loadedFileModified = fileModified;
+		loadedCharset = charsetValue;
+		loadedTrennzeichen = trennzeichenValue;
+		loadedSkipLines = skipLinesValue;
 	}
 
 	private List<String> getCsvValues(CSVRecord csvRecord) {


### PR DESCRIPTION
Core dump trace (subset)
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f7a70d51e8d, pid=177731, tid=177738
#
# JRE version: OpenJDK Runtime Environment (Red_Hat-25.0.3.0.9-1) (25.0.3+9) (build 25.0.3+9)
# Java VM: OpenJDK 64-Bit Server VM (Red_Hat-25.0.3.0.9-1) (25.0.3+9, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# C  [libgdk-3.so.0+0x52e8d]
#
# Core dump will be written. Default location: Determined by the following: "/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h %d %F" (alternatively, falling back to /home/thomas/jameica/core.177731)
#
# If you would like to submit a bug report, please visit:
#   https://bugzilla.redhat.com/enter_bug.cgi?product=Fedora&component=java-25-openjdk&version=42
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#

---------------  S U M M A R Y ------------

Command Line: -Djava.net.preferIPv4Stack=true -Xmx2048m -Xss64m jameica-linux64.jar

Host: AMD Ryzen 9 7950X3D 16-Core Processor, 32 cores, 62G, Fedora release 44 (Forty Four)
Time: Sun Jul  5 20:51:36 2026 CEST elapsed time: 63.794147 seconds (0d 0h 1m 3s)

---------------  T H R E A D  ---------------

Current thread (0x00007f7a9c02ba30):  JavaThread "main"             [_thread_in_native, id=177738, stack(0x00007f7aa1c00000,0x00007f7aa5c00000) (65536K)]

Stack: [0x00007f7aa1c00000,0x00007f7aa5c00000],  sp=0x00007f7aa5bfd300,  free space=65524k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libgdk-3.so.0+0x52e8d]
C  [libgdk-3.so.0+0x28e38]
C  [libgdk-3.so.0+0x296d8]  gdk_window_begin_draw_frame+0x78
C  [libgtk-3.so.0+0x3187df]
C  [libgtk-3.so.0+0x1991e3]  gtk_main_do_event+0x1093
C  [libswt-pi3-gtk-4970r5.so+0x55e26]  Java_org_eclipse_swt_internal_gtk3_GTK3_gtk_1main_1do_1event+0xc
Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
J 1815  org.eclipse.swt.internal.gtk3.GTK3.gtk_main_do_event(J)V (0 bytes) @ 0x00007f7a8c0851c9 [0x00007f7a8c085180+0x0000000000000049]
J 7595 c2 org.eclipse.swt.widgets.Display.eventProc(JJ)J (212 bytes) @ 0x00007f7a8c3a2ba8 [0x00007f7a8c3a2b00+0x00000000000000a8]
v  ~StubRoutines::call_stub 0x00007f7a8b817fa6
J 1823  org.eclipse.swt.internal.gtk3.GTK3.gtk_main_iteration_do(Z)Z (0 bytes) @ 0x00007f7a8c0857c9 [0x00007f7a8c085780+0x0000000000000049]
J 7830 c2 org.eclipse.swt.widgets.Display.readAndDispatch()Z (88 bytes) @ 0x00007f7a8c3bd5e4 [0x00007f7a8c3bd500+0x00000000000000e4]
j  de.willuhn.jameica.gui.dialogs.AbstractDialog$4.run()V+607
j  org.eclipse.swt.widgets.Synchronizer.syncExec(Ljava/lang/Runnable;)V+99
j  org.eclipse.swt.widgets.Display.syncExec(Ljava/lang/Runnable;)V+98
j  de.willuhn.jameica.gui.dialogs.AbstractDialog.open()Ljava/lang/Object;+27
j  de.open4me.depot.tools.CSVImportHelper.run(Ljava/util/ArrayList;Z)Ljava/util/List;+328
j  de.open4me.depot.tools.io.KurseViaFileCSV$1.run()V+9
j  org.eclipse.swt.widgets.RunnableLock.run(Lorg/eclipse/swt/widgets/Display;)V+11
J 7079 c1 org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Z)Z (188 bytes) @ 0x00007f7a84fc47dc [0x00007f7a84fc4480+0x000000000000035c]
J 2802 c1 org.eclipse.swt.widgets.Display.readAndDispatch()Z (88 bytes) @ 0x00007f7a84845594 [0x00007f7a84845200+0x0000000000000394]
j  de.willuhn.jameica.gui.GUI.loop()V+38
j  de.willuhn.jameica.gui.GUI.init()V+981
j  de.willuhn.jameica.system.Application.init()V+131
j  de.willuhn.jameica.system.Application.newInstance(Lde/willuhn/jameica/system/StartupParams;)V+57
j  de.willuhn.jameica.Main.main([Ljava/lang/String;)V+8
v  ~StubRoutines::call_stub 0x00007f7a8b817fa6
```

render only 100 lines of preview in stage 1 and stage 2. Finally limit dialog size to 90% of monitor size