### PR TITLE
Erweiterung der Praezision auf 8 Nachkommastellen (dbversion 19)

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -77,7 +77,7 @@
 		<mkdir dir="${class.dir}" />
 
 		<javac debug="true" debuglevel="lines,vars,source" deprecation="true"
-		       source="${define.java.version}" target="${define.java.version}"
+		       release="${define.java.version}"
 		       includeantruntime="false"
 		       encoding="${define.encoding}"
 		       srcdir="${src.dir}"

--- a/database.md
+++ b/database.md
@@ -84,7 +84,7 @@ und blieb bis v18 bei `decimal(10,5)` — das war die einzige Spalte, die noch a
 7. **[OrderSearchProvider.java:73](src/de/open4me/depot/search/OrderSearchProvider.java#L73)** —
    `VarDecimalFormat(5)` für Suchergebnisse. → jetzt `VarDecimalFormat(5, 3)`.
 8. Listen-Spalten (reine Anzeige, unverändert gelassen):
-   `OrderListControl`/`BestandTableControl` zeigen Anzahl mit `%,.5f`, Kurs mit
+   `OrderListControl`/`BestandTableControl` zeigen Anzahl mit `%,.8f`, Kurs mit
    `%,.6f`, Beträge mit `%,.2f`; `WertpapiereDatenControl` zeigt Kurse mit `%.6f`.
    Diese Formatierungen betreffen nur die Darstellung in Tabellen, nicht die
    gespeicherten Werte.

--- a/database.md
+++ b/database.md
@@ -1,0 +1,185 @@
+# DepotViewer — Datenbank und Zahlen-Präzision
+
+Stand: dbversion 19 (Branch `feat/precision-8`). Dieses Dokument beschreibt, wo
+Beträge, Kurse, Gebühren und Steuern gespeichert werden, wo die Präzision bisher
+begrenzt war (5 bzw. 6 Nachkommastellen) und was mit der Erweiterung auf
+8 Nachkommastellen geändert wurde.
+
+## Architektur-Überblick
+
+Der DepotViewer legt seine Tabellen in der **Hibiscus-Datenbank** an
+(`SQLUtils.getConnection()` holt die Verbindung über den Hibiscus-`HBCIDBService`).
+Unterstützte Datenbanken sind damit **H2** (Hibiscus-Standard) und **MySQL/MariaDB**
+(`DBSupportH2Impl` / `DBSupportMySqlImpl`, siehe `SQLUtils.getDateDiff()`).
+
+Schema-Änderungen laufen ausschließlich über
+[`SQLChange.getChangesSinceVersion()`](src/de/open4me/depot/sql/SQLChange.java):
+Beim Start führt `SQLUtils.checkforupdates()` alle Changesets aus, deren Version
+größer als der Wert `dbversion` in `depotviewer_cfg` ist. Es gibt kein separates
+"frisches" Schema — auch eine Neuinstallation durchläuft alle Versionen 3 → 19.
+Die Dateien unter [sql/](sql/) sind generierte, konsolidierte Abbilder des Schemas
+zu Dokumentationszwecken.
+
+## Wo werden Beträge gespeichert?
+
+| Tabelle | Spalte | Bedeutung | bis v18 | ab v19 |
+|---|---|---|---|---|
+| `depotviewer_umsaetze` | `anzahl` | Stückzahl der Order | `decimal(20,10)` | unverändert `decimal(20,10)` |
+| `depotviewer_umsaetze` | `kurs` | Kurs pro Stück | `decimal(20,6)` | `decimal(20,8)` |
+| `depotviewer_umsaetze` | `kosten` | Gesamtbetrag der Order | `decimal(20,6)` | `decimal(20,8)` |
+| `depotviewer_umsaetze` | `transaktionskosten` | Gebühren | `decimal(20,6)` | `decimal(20,8)` |
+| `depotviewer_umsaetze` | `steuern` | Steuern | `decimal(20,6)` | `decimal(20,8)` |
+| `depotviewer_bestand` | `anzahl` | Stückzahl im Bestand | `decimal(20,10)` | unverändert |
+| `depotviewer_bestand` | `kurs` | Bewertungskurs | `decimal(20,6)` | `decimal(20,8)` |
+| `depotviewer_bestand` | `wert` | Positionswert | `decimal(20,6)` | `decimal(20,8)` |
+| `depotviewer_kurse` | `kurs` | historischer Kurs | `decimal(20,6)` | `decimal(20,8)` |
+| `depotviewer_kurse` | `kursperf` | bereinigter Kurs | `decimal(20,6)` | `decimal(20,8)` |
+| `depotviewer_kursevent` | `value` | Dividende pro Stück | **`decimal(10,5)`** | `decimal(20,8)` |
+
+Historie der Präzision: v3–v15 speicherten Geldbeträge mit `decimal(20,2)`;
+v16 erweiterte auf `decimal(20,6)`. `depotviewer_kursevent.value` stammt aus v7
+und blieb bis v18 bei `decimal(10,5)` — das war die einzige Spalte, die noch auf
+5 Nachkommastellen begrenzt war. **v19** hebt alle Geld-/Kurs-Spalten auf
+`decimal(20,8)` an.
+
+## Gefundene 5-Nachkommastellen-Begrenzungen (vor diesem Branch)
+
+### Datenbank (verlustbehaftet — Werte wurden gerundet gespeichert)
+
+1. **`depotviewer_kursevent.value decimal(10,5)`**
+   ([SQLChange.java](src/de/open4me/depot/sql/SQLChange.java), Changeset v7).
+   Dividenden pro Stück wurden auf 5 Nachkommastellen gerundet. → v19: `decimal(20,8)`.
+2. Alle übrigen Geldspalten waren seit v16 auf **6** Nachkommastellen begrenzt
+   (`decimal(20,6)`), siehe Tabelle oben. → v19: 8 Nachkommastellen.
+
+### Backend (verlustbehaftet — Rundung vor dem Speichern)
+
+3. **[BestandImportAction.java:101](src/de/open4me/depot/gui/action/BestandImportAction.java#L101)** —
+   beim CSV-Bestandsimport wurde ein fehlender Kurs als `wert / anzahl` mit
+   **Scale 5** (`divide(..., 5, HALF_UP)`) berechnet. → jetzt Scale 8.
+4. **[UmsatzImportAction.java:124](src/de/open4me/depot/gui/action/UmsatzImportAction.java#L124)** —
+   beim CSV-Orderimport wurde ein fehlender Kurs als `kosten / anzahl` mit
+   **Scale 5** berechnet. → jetzt Scale 8.
+
+### Frontend / GUI (verlustbehaftet beim Editier-Roundtrip)
+
+5. **[UmsatzEditorControl.java](src/de/open4me/depot/gui/control/UmsatzEditorControl.java)** —
+   die Eingabefelder Anzahl, Einzelkurs, Kurswert, Transaktionskosten und Steuern
+   verwendeten `DecimalInput` mit `VarDecimalFormat(2, 3)` = 2 feste + max. 3
+   zusätzliche = **maximal 5 angezeigte Nachkommastellen**. Beim Öffnen einer
+   bestehenden Order wurde der Wert auf 5 Stellen gerundet angezeigt und beim
+   Speichern der gerundete Anzeigetext zurückgeschrieben — d. h. jede Bearbeitung
+   rundete gespeicherte Werte auf 5 Nachkommastellen. → jetzt `VarDecimalFormat(2, 6)`
+   (bis zu 8 Nachkommastellen).
+   Das Feld „Gesamtsumme" bleibt bewusst bei 2 Nachkommastellen (reine Anzeige eines
+   berechneten EUR-Betrags; gespeichert wird `kosten` aus dem Kurswert-Feld).
+
+### Nur Anzeige (nicht verlustbehaftet für die DB, aber auf 5 Stellen gekappt)
+
+6. **[UmsatzHelper.java:41](src/de/open4me/depot/tools/UmsatzHelper.java#L41)** —
+   `VarDecimalFormat(5)` beim Übertrag eines Depot-Umsatzes in den Hibiscus-Umsatz
+   (Verwendungszweck-Text „Kurs: …", „… STK"). → jetzt `VarDecimalFormat(5, 3)`:
+   weiterhin 5 feste Nachkommastellen (Textformat bleibt kompatibel), aber bis zu
+   8 wenn tatsächlich mehr Präzision vorhanden ist.
+7. **[OrderSearchProvider.java:73](src/de/open4me/depot/search/OrderSearchProvider.java#L73)** —
+   `VarDecimalFormat(5)` für Suchergebnisse. → jetzt `VarDecimalFormat(5, 3)`.
+8. Listen-Spalten (reine Anzeige, unverändert gelassen):
+   `OrderListControl`/`BestandTableControl` zeigen Anzahl mit `%,.5f`, Kurs mit
+   `%,.6f`, Beträge mit `%,.2f`; `WertpapiereDatenControl` zeigt Kurse mit `%.6f`.
+   Diese Formatierungen betreffen nur die Darstellung in Tabellen, nicht die
+   gespeicherten Werte.
+
+### Bekannte, nicht geänderte Präzisionsgrenzen
+
+- `anzahl` ist mit `decimal(20,10)` bereits genauer als 8 Stellen — unverändert.
+- Mehrere Abrufwege reichen Werte als `double` durch (z. B.
+  `Utils.addUmsatz(..., Double kurs, ...)`, `HBCIDepotBestandJob` mit
+  `getValue().doubleValue()`). `double` trägt ~15–16 signifikante Stellen und ist
+  damit für 8 Nachkommastellen bei üblichen Kursen ausreichend; eine Umstellung
+  auf durchgängig `BigDecimal` wäre eine separate Refaktorierung.
+- `WertBerechnung.java:136` rechnet bereits mit Scale 8, `UpdateStock` (Splitfaktor)
+  mit Scale 10.
+
+## Migration v19
+
+Neues Changeset in [`SQLChange.java`](src/de/open4me/depot/sql/SQLChange.java).
+**Wichtig:** Ab v19 sind die Statements datenbankspezifisch, denn H2 2.x (das
+aktuelle Jameica/Hibiscus bündelt H2 2.3) versteht das MySQL-`MODIFY COLUMN`
+der älteren Changesets nicht mehr, und MySQL versteht das H2-`ALTER COLUMN <typ>`
+nicht. `SQLChange.getChangesSinceVersion(version, mysql)` liefert deshalb je
+Datenbank die passende Variante (gleiches Muster wie die Hibiscus-eigenen
+Updates, z. B. `update0065.java`); `SQLUtils.checkforupdates()` wählt anhand des
+Hibiscus-Treibers (`DBSupportMySqlImpl`).
+
+H2:
+
+```sql
+ALTER TABLE depotviewer_umsaetze  ALTER COLUMN kurs               decimal(20,8);
+ALTER TABLE depotviewer_umsaetze  ALTER COLUMN kosten             decimal(20,8);
+ALTER TABLE depotviewer_umsaetze  ALTER COLUMN transaktionskosten decimal(20,8);
+ALTER TABLE depotviewer_umsaetze  ALTER COLUMN steuern            decimal(20,8);
+ALTER TABLE depotviewer_bestand   ALTER COLUMN kurs               decimal(20,8);
+ALTER TABLE depotviewer_bestand   ALTER COLUMN wert               decimal(20,8);
+ALTER TABLE depotviewer_kurse     ALTER COLUMN kurs               decimal(20,8);
+ALTER TABLE depotviewer_kurse     ALTER COLUMN kursperf           decimal(20,8);
+ALTER TABLE depotviewer_kursevent ALTER COLUMN "VALUE"            decimal(20,8);
+```
+
+(`value` ist in H2 2.x ein Schlüsselwort und muss gequotet werden; unquotierte
+Bezeichner wurden beim Anlegen unter H2 1.x in Großbuchstaben gespeichert,
+daher `"VALUE"`.)
+
+MySQL/MariaDB (Stil wie v16):
+
+```sql
+ALTER TABLE depotviewer_umsaetze  MODIFY COLUMN `kurs`               decimal(20,8);
+-- … analog für kosten, transaktionskosten, steuern, bestand.kurs/wert,
+--    kurse.kurs/kursperf, kursevent.`value`
+```
+
+### Abwärtskompatibilität
+
+- Die H2-Variante (`ALTER TABLE … ALTER COLUMN <spalte> <typ>`) funktioniert in
+  H2 1.x **und** im Standardmodus von H2 2.x (empirisch mit H2 2.3.232 geprüft);
+  die MySQL-Variante entspricht der bereits in v10/v16 verwendeten Syntax.
+- Hinweis (vorbestehend, nicht Teil dieses Branches): Eine **Neuinstallation**
+  auf H2 2.x schlägt bereits im Changeset v3 fehl (`int(10)`, Spaltenname
+  `value`), unabhängig von v19. Bestehende Datenbanken sind nicht betroffen,
+  da ihre Tabellen unter H2 1.x angelegt und per Jameica-Migration in das
+  2.x-Format überführt wurden.
+- Die Scale wird nur **erweitert** (2/5/6 → 8). Bestehende Werte werden von beiden
+  Datenbanken verlustfrei übernommen (Auffüllen mit Nullen, keine Rundung). Der
+  Unit-Test `PrecisionTest.migrationV19ErhaeltBestehendeWerteH2` weist das nach.
+- Die Precision 20 bleibt erhalten; der ganzzahlige Anteil sinkt von 14 auf
+  12 Stellen (`decimal(20,8)`), was für Beträge weiterhin bis zu 999 Milliarden
+  zulässt. Für `kursevent.value` wächst die Kapazität (10,5 → 20,8).
+- Ältere Datenbestände (Version < 19) werden beim ersten Start automatisch
+  migriert; ein Downgrade des Plugins nach der Migration würde — wie bei allen
+  bisherigen Schema-Erweiterungen — von den alten Formaten toleriert, da die
+  alten Versionen nur mit größerer Rundung schreiben.
+- Konsolidiertes Schema: [sql/depotviewer_schema_v19.sql](sql/depotviewer_schema_v19.sql)
+  (v18-Datei bleibt als historisches Abbild erhalten).
+
+## Tests
+
+[test/database/PrecisionTest.java](test/database/PrecisionTest.java) (H2, JUnit 4):
+
+- **Roundtrip-Tests** pro Tabelle: Werte mit 8 Nachkommastellen werden eingefügt
+  und wieder ausgelesen; der zurückgelesene `BigDecimal` muss numerisch exakt dem
+  eingefügten entsprechen (`compareTo == 0`).
+- **Migrationstest**: Schema wird bis v18 aufgebaut, Alt-Werte mit 6 (bzw. 5 für
+  `kursevent.value`) Nachkommastellen eingefügt, dann v19 angewendet. Die
+  Alt-Werte müssen unverändert erhalten bleiben, und anschließend müssen
+  8-stellige Werte speicherbar sein.
+- Der bestehende Test `DataBaseCreation` prüft weiterhin, dass die komplette
+  Changeset-Kette 0 → aktuell auf einer leeren Datenbank durchläuft
+  (mit H2 1.x bzw. MySQL; siehe Hinweis oben zu Neuinstallationen auf H2 2.x).
+
+Ausführen (es gibt kein Ant-Test-Target; JUnit 4 + H2-Treiber genügen):
+
+```sh
+javac -d /tmp/testbin -cp junit-4.13.2.jar \
+    src/de/open4me/depot/sql/SQLChange.java test/database/PrecisionTest.java
+java -cp /tmp/testbin:junit-4.13.2.jar:hamcrest-core-1.3.jar:h2-2.3.232.jar \
+    org.junit.runner.JUnitCore database.PrecisionTest
+```

--- a/sql/depotviewer_schema_v18.sql
+++ b/sql/depotviewer_schema_v18.sql
@@ -1,0 +1,96 @@
+-- Consolidated schema for hibiscus.depotviewer at dbversion 18.
+-- Generated from src/de/open4me/depot/sql/SQLChange.java (versions 3-18 folded together).
+-- Contains only CREATE TABLE / index statements, no ALTER TABLE.
+
+DROP TABLE IF EXISTS depotviewer_kursevent;
+DROP TABLE IF EXISTS depotviewer_cfgupdatestock;
+DROP TABLE IF EXISTS depotviewer_umsaetze;
+DROP TABLE IF EXISTS depotviewer_bestand;
+DROP TABLE IF EXISTS depotviewer_kurse;
+DROP TABLE IF EXISTS depotviewer_wertpapier;
+DROP TABLE IF EXISTS depotviewer_cfg;
+
+CREATE TABLE depotviewer_cfg (
+  id int NOT NULL auto_increment,
+  `key` varchar(200) COMMENT 'Setting name, e.g. dbversion, status_bestand_order, or csv.<savename>.<source>.* import-profile keys',
+  value varchar(2000) COMMENT 'Setting value as text (int string for dbversion, boolean-like for status_bestand_order, free text for CSV import options)',
+  PRIMARY KEY (id)
+) COMMENT='Generic key/value settings store for the plugin, not tied to a specific security';
+
+CREATE TABLE depotviewer_wertpapier (
+  id int NOT NULL auto_increment,
+  wertpapiername varchar(255) NOT NULL COMMENT 'Display name of the security',
+  wkn varchar(6) NOT NULL COMMENT 'German Wertpapierkennnummer, used for lookup and as a fallback quote-provider search term',
+  isin varchar(12) NOT NULL COMMENT 'ISIN, primary lookup key and preferred quote-provider search term',
+  PRIMARY KEY (id)
+) COMMENT='Master data for one security (stock/fund) tracked by the depot viewer';
+
+CREATE TABLE depotviewer_umsaetze (
+  id int NOT NULL auto_increment,
+  wpid int COMMENT 'References depotviewer_wertpapier.id: the security this transaction is for',
+  kontoid int(10) COMMENT 'References konto.id (Hibiscus account): the account this transaction belongs to',
+  anzahl decimal(20,10) COMMENT 'Number of units/shares transacted (always positive)',
+  kurs decimal(20,6) COMMENT 'Price per unit for the transaction',
+  kursw varchar(3) NOT NULL COMMENT 'ISO currency code of kurs',
+  kosten decimal(20,6) COMMENT 'Total transaction amount (Anzahl x Kurs, adjusted); negative for purchases, positive for sales/outbound bookings',
+  kostenw varchar(3) NOT NULL COMMENT 'ISO currency code of kosten',
+  aktion varchar(30) NOT NULL COMMENT 'Transaction type: KAUF (purchase), VERKAUF (sale), EINLIEFERUNG (inbound transfer), AUSLIEFERUNG (outbound transfer), see DepotAktion',
+  buchungsdatum date COMMENT 'Booking/settlement date of the transaction',
+  buchungsinformationen varchar(2000) COMMENT 'Free-text booking description, typically taken verbatim from the bank/broker statement or import source',
+  orderid varchar(50) COMMENT 'Dedup/identity key for the transaction: broker order id if known, otherwise a synthetic hash of key fields, used to skip duplicate imports',
+  kommentar varchar(2000) COMMENT 'Free-text user comment/note on the transaction, editable in the UI',
+  transaktionskosten decimal(20,6) COMMENT 'Broker/transaction fees charged for this order',
+  transaktionskostenw varchar(3) COMMENT 'ISO currency code of transaktionskosten',
+  steuern decimal(20,6) COMMENT 'Taxes withheld/charged on this transaction',
+  steuernw varchar(3) COMMENT 'ISO currency code of steuern',
+  PRIMARY KEY (id),
+  CONSTRAINT fkdvumsaetze FOREIGN KEY (kontoid) REFERENCES konto (id) ON DELETE CASCADE
+) COMMENT='Booked depot transactions/orders (buys, sells, inbound/outbound transfers of securities)';
+
+CREATE TABLE depotviewer_bestand (
+  id int NOT NULL auto_increment,
+  wpid int COMMENT 'References depotviewer_wertpapier.id: the security held',
+  kontoid int(10) COMMENT 'References konto.id (Hibiscus account): the account holding the position',
+  anzahl decimal(20,10) COMMENT 'Quantity of units held at snapshot time',
+  kurs decimal(20,6) COMMENT 'Price per unit at valuation time',
+  kursw varchar(3) NOT NULL COMMENT 'ISO currency code of kurs',
+  wert decimal(20,6) COMMENT 'Total value of the position (Anzahl x Kurs / Depotwert) as reported by the bank',
+  wertw varchar(3) NOT NULL COMMENT 'ISO currency code of wert',
+  datum date NOT NULL COMMENT 'Date the depot snapshot/retrieval was taken',
+  bewertungszeitpunkt date COMMENT 'Bank-supplied timestamp at which the price used for this position was determined; can differ per position within a snapshot',
+  PRIMARY KEY (id),
+  CONSTRAINT fkdvbestand FOREIGN KEY (kontoid) REFERENCES konto (id) ON DELETE CASCADE
+) COMMENT='Point-in-time snapshot of held positions (portfolio holdings)';
+
+CREATE TABLE depotviewer_kurse (
+  id int NOT NULL auto_increment,
+  wpid int COMMENT 'References depotviewer_wertpapier.id: the security this quote belongs to',
+  kurs decimal(20,6) COMMENT 'Raw quoted price on kursdatum',
+  kursw varchar(3) NOT NULL COMMENT 'ISO currency code of kurs',
+  kursdatum date COMMENT 'Date of the quote',
+  kursperf decimal(20,6) COMMENT 'Corporate-action-adjusted ("performance"/adjusted-close) price, derived from kurs by applying depotviewer_kursevent splits and dividends so historical values are comparable to today''s price',
+  PRIMARY KEY (id)
+) COMMENT='Historical daily price series per security';
+
+CREATE INDEX idxKurseWpid ON depotviewer_kurse (wpid);
+CREATE INDEX idxKurseDatum ON depotviewer_kurse (kursdatum);
+CREATE INDEX idxKurseId ON depotviewer_kurse (id);
+
+CREATE TABLE depotviewer_kursevent (
+  id int NOT NULL auto_increment,
+  wpid int COMMENT 'References depotviewer_wertpapier.id: the security affected by this corporate action',
+  ratio varchar(30) COMMENT 'Colon-separated ratio (e.g. "2:1"), used for split-type events (S/R/G) to compute the price-adjustment factor',
+  value decimal(10,5) COMMENT 'Per-share monetary amount, used for cash-dividend events (D) as the amount subtracted from the adjusted price; meaning for other event types is unused/ambiguous in code',
+  aktion varchar(100) NOT NULL COMMENT 'Event-type code (see KursEventAktion): D=Dividende, G=Aktien-Dividende, S=Split, R=Reverse Split, B=Bezugsrecht (stored but not fully consumed by the performance calc)',
+  datum date COMMENT 'Date the corporate action took effect (ex-date), used to order events for the performance-price walk',
+  waehrung varchar(3) COMMENT 'ISO currency code associated with the event (e.g. the dividend currency); not consumed in the adjustment calculation',
+  PRIMARY KEY (id)
+) COMMENT='Corporate actions (splits, dividends, subscription rights) affecting a security''s price history';
+
+CREATE TABLE depotviewer_cfgupdatestock (
+  id int NOT NULL auto_increment,
+  wpid int COMMENT 'References depotviewer_wertpapier.id: the security these settings apply to',
+  `key` varchar(200) COMMENT 'NULL for the selected quote-provider name in value, otherwise the description of a provider-specific config option answered in value',
+  value varchar(200) COMMENT 'Selected quote-provider name (when key is NULL) or the chosen answer for the named config option',
+  PRIMARY KEY (id)
+) COMMENT='Per-security settings remembered for the automatic price-update job, so it does not re-prompt the user';

--- a/sql/depotviewer_schema_v19.sql
+++ b/sql/depotviewer_schema_v19.sql
@@ -1,0 +1,96 @@
+-- Consolidated schema for hibiscus.depotviewer at dbversion 19.
+-- Generated from src/de/open4me/depot/sql/SQLChange.java (versions 3-19 folded together).
+-- Contains only CREATE TABLE / index statements, no ALTER TABLE.
+
+DROP TABLE IF EXISTS depotviewer_kursevent;
+DROP TABLE IF EXISTS depotviewer_cfgupdatestock;
+DROP TABLE IF EXISTS depotviewer_umsaetze;
+DROP TABLE IF EXISTS depotviewer_bestand;
+DROP TABLE IF EXISTS depotviewer_kurse;
+DROP TABLE IF EXISTS depotviewer_wertpapier;
+DROP TABLE IF EXISTS depotviewer_cfg;
+
+CREATE TABLE depotviewer_cfg (
+  id int NOT NULL auto_increment,
+  `key` varchar(200) COMMENT 'Setting name, e.g. dbversion, status_bestand_order, or csv.<savename>.<source>.* import-profile keys',
+  value varchar(2000) COMMENT 'Setting value as text (int string for dbversion, boolean-like for status_bestand_order, free text for CSV import options)',
+  PRIMARY KEY (id)
+) COMMENT='Generic key/value settings store for the plugin, not tied to a specific security';
+
+CREATE TABLE depotviewer_wertpapier (
+  id int NOT NULL auto_increment,
+  wertpapiername varchar(255) NOT NULL COMMENT 'Display name of the security',
+  wkn varchar(6) NOT NULL COMMENT 'German Wertpapierkennnummer, used for lookup and as a fallback quote-provider search term',
+  isin varchar(12) NOT NULL COMMENT 'ISIN, primary lookup key and preferred quote-provider search term',
+  PRIMARY KEY (id)
+) COMMENT='Master data for one security (stock/fund) tracked by the depot viewer';
+
+CREATE TABLE depotviewer_umsaetze (
+  id int NOT NULL auto_increment,
+  wpid int COMMENT 'References depotviewer_wertpapier.id: the security this transaction is for',
+  kontoid int(10) COMMENT 'References konto.id (Hibiscus account): the account this transaction belongs to',
+  anzahl decimal(20,10) COMMENT 'Number of units/shares transacted (always positive)',
+  kurs decimal(20,8) COMMENT 'Price per unit for the transaction',
+  kursw varchar(3) NOT NULL COMMENT 'ISO currency code of kurs',
+  kosten decimal(20,8) COMMENT 'Total transaction amount (Anzahl x Kurs, adjusted); negative for purchases, positive for sales/outbound bookings',
+  kostenw varchar(3) NOT NULL COMMENT 'ISO currency code of kosten',
+  aktion varchar(30) NOT NULL COMMENT 'Transaction type: KAUF (purchase), VERKAUF (sale), EINLIEFERUNG (inbound transfer), AUSLIEFERUNG (outbound transfer), see DepotAktion',
+  buchungsdatum date COMMENT 'Booking/settlement date of the transaction',
+  buchungsinformationen varchar(2000) COMMENT 'Free-text booking description, typically taken verbatim from the bank/broker statement or import source',
+  orderid varchar(50) COMMENT 'Dedup/identity key for the transaction: broker order id if known, otherwise a synthetic hash of key fields, used to skip duplicate imports',
+  kommentar varchar(2000) COMMENT 'Free-text user comment/note on the transaction, editable in the UI',
+  transaktionskosten decimal(20,8) COMMENT 'Broker/transaction fees charged for this order',
+  transaktionskostenw varchar(3) COMMENT 'ISO currency code of transaktionskosten',
+  steuern decimal(20,8) COMMENT 'Taxes withheld/charged on this transaction',
+  steuernw varchar(3) COMMENT 'ISO currency code of steuern',
+  PRIMARY KEY (id),
+  CONSTRAINT fkdvumsaetze FOREIGN KEY (kontoid) REFERENCES konto (id) ON DELETE CASCADE
+) COMMENT='Booked depot transactions/orders (buys, sells, inbound/outbound transfers of securities)';
+
+CREATE TABLE depotviewer_bestand (
+  id int NOT NULL auto_increment,
+  wpid int COMMENT 'References depotviewer_wertpapier.id: the security held',
+  kontoid int(10) COMMENT 'References konto.id (Hibiscus account): the account holding the position',
+  anzahl decimal(20,10) COMMENT 'Quantity of units held at snapshot time',
+  kurs decimal(20,8) COMMENT 'Price per unit at valuation time',
+  kursw varchar(3) NOT NULL COMMENT 'ISO currency code of kurs',
+  wert decimal(20,8) COMMENT 'Total value of the position (Anzahl x Kurs / Depotwert) as reported by the bank',
+  wertw varchar(3) NOT NULL COMMENT 'ISO currency code of wert',
+  datum date NOT NULL COMMENT 'Date the depot snapshot/retrieval was taken',
+  bewertungszeitpunkt date COMMENT 'Bank-supplied timestamp at which the price used for this position was determined; can differ per position within a snapshot',
+  PRIMARY KEY (id),
+  CONSTRAINT fkdvbestand FOREIGN KEY (kontoid) REFERENCES konto (id) ON DELETE CASCADE
+) COMMENT='Point-in-time snapshot of held positions (portfolio holdings)';
+
+CREATE TABLE depotviewer_kurse (
+  id int NOT NULL auto_increment,
+  wpid int COMMENT 'References depotviewer_wertpapier.id: the security this quote belongs to',
+  kurs decimal(20,8) COMMENT 'Raw quoted price on kursdatum',
+  kursw varchar(3) NOT NULL COMMENT 'ISO currency code of kurs',
+  kursdatum date COMMENT 'Date of the quote',
+  kursperf decimal(20,8) COMMENT 'Corporate-action-adjusted ("performance"/adjusted-close) price, derived from kurs by applying depotviewer_kursevent splits and dividends so historical values are comparable to today''s price',
+  PRIMARY KEY (id)
+) COMMENT='Historical daily price series per security';
+
+CREATE INDEX idxKurseWpid ON depotviewer_kurse (wpid);
+CREATE INDEX idxKurseDatum ON depotviewer_kurse (kursdatum);
+CREATE INDEX idxKurseId ON depotviewer_kurse (id);
+
+CREATE TABLE depotviewer_kursevent (
+  id int NOT NULL auto_increment,
+  wpid int COMMENT 'References depotviewer_wertpapier.id: the security affected by this corporate action',
+  ratio varchar(30) COMMENT 'Colon-separated ratio (e.g. "2:1"), used for split-type events (S/R/G) to compute the price-adjustment factor',
+  value decimal(20,8) COMMENT 'Per-share monetary amount, used for cash-dividend events (D) as the amount subtracted from the adjusted price; meaning for other event types is unused/ambiguous in code',
+  aktion varchar(100) NOT NULL COMMENT 'Event-type code (see KursEventAktion): D=Dividende, G=Aktien-Dividende, S=Split, R=Reverse Split, B=Bezugsrecht (stored but not fully consumed by the performance calc)',
+  datum date COMMENT 'Date the corporate action took effect (ex-date), used to order events for the performance-price walk',
+  waehrung varchar(3) COMMENT 'ISO currency code associated with the event (e.g. the dividend currency); not consumed in the adjustment calculation',
+  PRIMARY KEY (id)
+) COMMENT='Corporate actions (splits, dividends, subscription rights) affecting a security''s price history';
+
+CREATE TABLE depotviewer_cfgupdatestock (
+  id int NOT NULL auto_increment,
+  wpid int COMMENT 'References depotviewer_wertpapier.id: the security these settings apply to',
+  `key` varchar(200) COMMENT 'NULL for the selected quote-provider name in value, otherwise the description of a provider-specific config option answered in value',
+  value varchar(200) COMMENT 'Selected quote-provider name (when key is NULL) or the chosen answer for the named config option',
+  PRIMARY KEY (id)
+) COMMENT='Per-security settings remembered for the automatic price-update job, so it does not re-prompt the user';

--- a/src/Tools/createClassesFromSQL.java
+++ b/src/Tools/createClassesFromSQL.java
@@ -71,7 +71,11 @@ public class createClassesFromSQL {
 			} else if (type.startsWith("date")) {
 				vartype = "Date";
 			} else if (type.startsWith("decimal")) {
-				vartype = "Double";
+				// Geldbetraege/Kurse immer als BigDecimal: JDBC liefert fuer
+				// decimal-Spalten BigDecimal, ein (Double)-Cast wuerde zur
+				// Laufzeit eine ClassCastException werfen.
+				// Die erzeugten Klassen brauchen dann import java.math.BigDecimal.
+				vartype = "BigDecimal";
 			} else if (type.startsWith("numeric")) {
 				vartype = "Integer";
 			} else {

--- a/src/de/open4me/depot/abruf/impl/CortalConsorsMitHBCIJSONWrapper.java
+++ b/src/de/open4me/depot/abruf/impl/CortalConsorsMitHBCIJSONWrapper.java
@@ -1,5 +1,7 @@
 package de.open4me.depot.abruf.impl;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.rmi.RemoteException;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -65,9 +67,9 @@ public class CortalConsorsMitHBCIJSONWrapper {
 					getDatum(), // Datum
 					getOrderID(), // orderid
 					"", // Kommentar
-					0.0d, // Gebuehren
-					"EUR", /// 
-					0.0d, // Steuern
+					BigDecimal.ZERO, // Gebuehren
+					"EUR", ///
+					BigDecimal.ZERO, // Steuern
 					"EUR" /// 
 			);
 		} catch (RemoteException | ApplicationException | ParseException e) {
@@ -96,21 +98,22 @@ public class CortalConsorsMitHBCIJSONWrapper {
 		return (String) detailInfo.get("2");
 	}
 
-	private Double getKosten() {
-		return (getOrderArt().equals("B") ? -1 : 1) *
-		Math.rint(getKurs() * getStueckzahl() * 100) / 100;
+	private BigDecimal getKosten() {
+		// Math.rint() rundete kaufmaennisch zur geraden Ziffer -> HALF_EVEN
+		BigDecimal kosten = getKurs().multiply(getStueckzahl()).setScale(2, RoundingMode.HALF_EVEN);
+		return getOrderArt().equals("B") ? kosten.negate() : kosten;
 	}
 
 	private String getKursW() {
 		return (String) detailInfo.get("2");
 	}
 
-	private Double getKurs() {
-		return Double.parseDouble(detailInfo.get("1").toString());
+	private BigDecimal getKurs() {
+		return new BigDecimal(detailInfo.get("1").toString());
 	}
 
-	private Double getStueckzahl() {
-		return Double.parseDouble(detailInfo.get("12").toString());
+	private BigDecimal getStueckzahl() {
+		return new BigDecimal(detailInfo.get("12").toString());
 	}
 
 	private String getOrderArt() {

--- a/src/de/open4me/depot/abruf/utils/Utils.java
+++ b/src/de/open4me/depot/abruf/utils/Utils.java
@@ -32,6 +32,7 @@ import de.open4me.depot.datenobj.rmi.Wertpapier;
 import de.open4me.depot.sql.GenericObjectHashMap;
 import de.open4me.depot.sql.GenericObjectSQL;
 import de.open4me.depot.sql.SQLUtils;
+import de.open4me.depot.tools.Zahlen;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.dialogs.YesNoDialog;
 import de.willuhn.jameica.hbci.rmi.Konto;
@@ -86,13 +87,10 @@ public class Utils {
 		return Application.getPluginLoader().getPlugin(class1).getResources().getWorkPath();
 	}
 
-	public static Double getDoubleFromZahl(String s) {
-		return Double.parseDouble(s.replace(".", "").replace(",","."));
-	}
-	
 	public static DepotAktion checkTransaktionsBezeichnung(String aktion) {
 		return DepotAktion.getByString(aktion);
 	}
+
 
 	/**
 	 * Speichert einen Wertpapier-Umsatz in der Datenbanktabelle DEPOTVIEWER_UMSATZ und liefert das erzeugte Umsatz-Objekt zurück.
@@ -112,12 +110,12 @@ public class Utils {
 	 * @param kommentar
 	 * @throws ApplicationException
 	 */
-	public static Umsatz addUmsatz(String kontoid, String wpid, String aktion, String info, Double anzahl, 
-			Double kurs, String kursW, Double kosten, String kostenW, Date date, String orderid, String kommentar,
-			Double gebuehren, String gebuehrenW, Double steuern, String steuernW) throws ApplicationException {
+	public static Umsatz addUmsatz(String kontoid, String wpid, String aktion, String info, BigDecimal anzahl,
+			BigDecimal kurs, String kursW, BigDecimal kosten, String kostenW, Date date, String orderid, String kommentar,
+			BigDecimal gebuehren, String gebuehrenW, BigDecimal steuern, String steuernW) throws ApplicationException {
 		try {
 			if (orderid == null) {
-				orderid = "" + ("" + kontoid + wpid + aktion + date + anzahl + kurs + kursW).hashCode();
+				orderid = Zahlen.berechneOrderId(kontoid, wpid, aktion, date, anzahl, kurs, kursW);
 				Logger.info("Transaction-ID is null. Calculate id to " + orderid);
 			}
 			DBIterator<Umsatz> liste = Settings.getDBService().createList(Umsatz.class);
@@ -131,8 +129,8 @@ public class Utils {
 				Logger.error("Unbekannte Buchungsart: " + aktion);
 				return null;
 			}
-			if ((a.equals(DepotAktion.KAUF) && (kosten > 0.0f))
-					|| (a.equals(DepotAktion.VERKAUF) && (kosten < 0.0f))) {
+			if ((a.equals(DepotAktion.KAUF) && (kosten.signum() > 0))
+					|| (a.equals(DepotAktion.VERKAUF) && (kosten.signum() < 0))) {
 				throw new ApplicationException("Bei Käufen muss der Gesamtbetrag negativ sein, beim Verkauf positiv. ("
 						+ aktion.toUpperCase() + " " + kosten + ")");
 			}
@@ -149,17 +147,17 @@ public class Utils {
 			p.setAktion(a);
 			p.setBuchungsinformationen(info);
 			p.setWPid(wpid);
-			p.setAnzahl(new BigDecimal(anzahl));
-			p.setKurs(new BigDecimal(kurs));
+			p.setAnzahl(anzahl);
+			p.setKurs(kurs);
 			p.setKursW(kursW);
-			p.setKosten(new BigDecimal(kosten));
+			p.setKosten(kosten);
 			p.setKostenW(kostenW);
 			p.setBuchungsdatum(date);
 			p.setOrderid(orderid);
 			p.setKommentar(kommentar);
-			p.setSteuern(new BigDecimal(steuern));
+			p.setSteuern(steuern);
 			p.setSteuernW(steuernW);
-			p.setTransaktionsgebuehren(new BigDecimal(gebuehren));
+			p.setTransaktionsgebuehren(gebuehren);
 			p.setTransaktionsgebuehrenW(gebuehrenW);
 			p.store();
 			
@@ -228,8 +226,8 @@ public class Utils {
 	}
 
 
-	public static void addBestand(String wpid, Konto konto, Double anzahl, 
-			Double kurs, String kursw, double wert, String wertw, Date date, Date bewertungsZeitpunkt) throws ApplicationException {
+	public static void addBestand(String wpid, Konto konto, BigDecimal anzahl,
+			BigDecimal kurs, String kursw, BigDecimal wert, String wertw, Date date, Date bewertungsZeitpunkt) throws ApplicationException {
 		try {
 			markRecalc(konto);
 			Bestand p = (Bestand) Settings.getDBService().createObject(Bestand.class,null);

--- a/src/de/open4me/depot/datenobj/rmi/Bestand.java
+++ b/src/de/open4me/depot/datenobj/rmi/Bestand.java
@@ -1,5 +1,6 @@
 package de.open4me.depot.datenobj.rmi;
 
+import java.math.BigDecimal;
 import java.rmi.RemoteException;
 import java.util.Date;
 
@@ -12,14 +13,14 @@ public interface Bestand extends DBObject
 	public void setKontoid(Integer name) throws RemoteException;
 	public String getWPid() throws RemoteException;
 	public void setWPid(String name) throws RemoteException;
-	public Double getAnzahl() throws RemoteException;
-	public void setAnzahl(Double name) throws RemoteException;
-	public Double getKurs() throws RemoteException;
-	public void setKurs(Double name) throws RemoteException;
+	public BigDecimal getAnzahl() throws RemoteException;
+	public void setAnzahl(BigDecimal name) throws RemoteException;
+	public BigDecimal getKurs() throws RemoteException;
+	public void setKurs(BigDecimal name) throws RemoteException;
 	public String getKursw() throws RemoteException;
 	public void setKursw(String name) throws RemoteException;
-	public Double getWert() throws RemoteException;
-	public void setWert(Double name) throws RemoteException;
+	public BigDecimal getWert() throws RemoteException;
+	public void setWert(BigDecimal name) throws RemoteException;
 	public String getWertw() throws RemoteException;
 	public void setWertw(String name) throws RemoteException;
 	public Date getDatum() throws RemoteException;

--- a/src/de/open4me/depot/datenobj/rmi/Kursevents.java
+++ b/src/de/open4me/depot/datenobj/rmi/Kursevents.java
@@ -1,5 +1,6 @@
 package de.open4me.depot.datenobj.rmi;
 
+import java.math.BigDecimal;
 import java.rmi.RemoteException;
 import java.util.Date;
 
@@ -10,8 +11,8 @@ public interface  Kursevents extends DBObject {
 	public void setWpid(Integer name) throws RemoteException;
 	public String getRatio() throws RemoteException;
 	public void setRatio(String name) throws RemoteException;
-	public Double getValue() throws RemoteException;
-	public void setValue(Double name) throws RemoteException;
+	public BigDecimal getValue() throws RemoteException;
+	public void setValue(BigDecimal name) throws RemoteException;
 	public String getAktion() throws RemoteException;
 	public void setAktion(String name) throws RemoteException;
 	public Date getDatum() throws RemoteException;

--- a/src/de/open4me/depot/datenobj/server/BestandImpl.java
+++ b/src/de/open4me/depot/datenobj/server/BestandImpl.java
@@ -43,21 +43,21 @@ public class BestandImpl extends AbstractDBObject implements Bestand
 	{
 		setAttribute("wpid",name);
 	}
-	public Double getAnzahl() throws RemoteException
+	public BigDecimal getAnzahl() throws RemoteException
 	{
-		return (Double) getAttribute("anzahl");
+		return (BigDecimal) getAttribute("anzahl");
 	}
 
-	public void setAnzahl(Double name) throws RemoteException
+	public void setAnzahl(BigDecimal name) throws RemoteException
 	{
 		setAttribute("anzahl",name);
 	}
-	public Double getKurs() throws RemoteException
+	public BigDecimal getKurs() throws RemoteException
 	{
-		return (Double) getAttribute("kurs");
+		return (BigDecimal) getAttribute("kurs");
 	}
 
-	public void setKurs(Double name) throws RemoteException
+	public void setKurs(BigDecimal name) throws RemoteException
 	{
 		setAttribute("kurs",name);
 	}
@@ -70,12 +70,12 @@ public class BestandImpl extends AbstractDBObject implements Bestand
 	{
 		setAttribute("kursw",name);
 	}
-	public Double getWert() throws RemoteException
+	public BigDecimal getWert() throws RemoteException
 	{
-		return ((BigDecimal) getAttribute("wert")).doubleValue();
+		return (BigDecimal) getAttribute("wert");
 	}
 
-	public void setWert(Double name) throws RemoteException
+	public void setWert(BigDecimal name) throws RemoteException
 	{
 		setAttribute("wert",name);
 	}

--- a/src/de/open4me/depot/datenobj/server/KurseventsImpl.java
+++ b/src/de/open4me/depot/datenobj/server/KurseventsImpl.java
@@ -1,5 +1,6 @@
 package de.open4me.depot.datenobj.server;
 
+import java.math.BigDecimal;
 import java.rmi.RemoteException;
 import java.util.Date;
 
@@ -56,12 +57,12 @@ public class KurseventsImpl extends AbstractDBObject implements Kursevents
 	{
 		setAttribute("ratio",name);
 	}
-	public Double getValue() throws RemoteException
+	public BigDecimal getValue() throws RemoteException
 	{
-		return (Double) getAttribute("value");
+		return (BigDecimal) getAttribute("value");
 	}
 
-	public void setValue(Double name) throws RemoteException
+	public void setValue(BigDecimal name) throws RemoteException
 	{
 		setAttribute("value",name);
 	}

--- a/src/de/open4me/depot/gui/action/BestandImportAction.java
+++ b/src/de/open4me/depot/gui/action/BestandImportAction.java
@@ -98,7 +98,7 @@ public class BestandImportAction implements Action {
 				}
 
 				if (x.getAttribute("kurs").toString().isEmpty()  && !x.getAttribute("wert").toString().isEmpty()) {
-					BigDecimal d = ((BigDecimal) x.getAttribute("wert")).divide((BigDecimal) x.getAttribute("anzahl"),5, RoundingMode.HALF_UP);
+					BigDecimal d = ((BigDecimal) x.getAttribute("wert")).divide((BigDecimal) x.getAttribute("anzahl"),8, RoundingMode.HALF_UP);
 					x.setAttribute("kurs", d);
 				}
 				if (!x.getAttribute("kurs").toString().isEmpty()  && x.getAttribute("wert").toString().isEmpty()) {

--- a/src/de/open4me/depot/gui/action/BestandImportAction.java
+++ b/src/de/open4me/depot/gui/action/BestandImportAction.java
@@ -140,10 +140,10 @@ public class BestandImportAction implements Action {
 				Utils.addBestand(
 						Utils.getORcreateWKN((String) x.getAttribute("wkn"), (String) x.getAttribute("isin"), (String) x.getAttribute("name")),
 						konto,
-						((BigDecimal) x.getAttribute("anzahl")).doubleValue(),
-						((BigDecimal) x.getAttribute("kurs")).doubleValue(),
+						(BigDecimal) x.getAttribute("anzahl"),
+						(BigDecimal) x.getAttribute("kurs"),
 						handleCurrency(kursW),
-						((BigDecimal) x.getAttribute("wert")).doubleValue(),
+						(BigDecimal) x.getAttribute("wert"),
 						handleCurrency(wertW),
 						(Date) x.getAttribute("date"),
 						(Date) x.getAttribute("date"));

--- a/src/de/open4me/depot/gui/action/UmsatzImportAction.java
+++ b/src/de/open4me/depot/gui/action/UmsatzImportAction.java
@@ -121,7 +121,7 @@ public class UmsatzImportAction implements Action {
 					x.setAttribute("anzahl", ((BigDecimal) x.getAttribute("anzahl")).abs());
 				}
 				if (x.getAttribute("kurs").toString().isEmpty()  && !x.getAttribute("kosten").toString().isEmpty()) {
-					BigDecimal d = ((BigDecimal) x.getAttribute("kosten")).divide((BigDecimal) x.getAttribute("anzahl"),5, RoundingMode.HALF_UP);
+					BigDecimal d = ((BigDecimal) x.getAttribute("kosten")).divide((BigDecimal) x.getAttribute("anzahl"),8, RoundingMode.HALF_UP);
 					x.setAttribute("kurs", d);
 				}
 				if (!x.getAttribute("kurs").toString().isEmpty()  && x.getAttribute("kosten").toString().isEmpty()) {

--- a/src/de/open4me/depot/gui/control/BestandPieChartControl.java
+++ b/src/de/open4me/depot/gui/control/BestandPieChartControl.java
@@ -2,6 +2,7 @@ package de.open4me.depot.gui.control;
 
 import java.awt.Font;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.AttributedString;
 import java.util.Date;
 
@@ -24,6 +25,7 @@ import org.jfree.util.SortOrder;
 import de.open4me.depot.gui.DatumsSlider;
 import de.open4me.depot.sql.GenericObjectSQL;
 import de.open4me.depot.tools.Bestandsabfragen;
+import de.open4me.depot.tools.Zahlen;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -75,7 +77,7 @@ public class BestandPieChartControl implements Listener
 		                try {
 		                    Number value = dataset.getValue(key);
 		                    if (value != null) {
-		                        long euroValue = Math.round(value.doubleValue());
+		                        long euroValue = Zahlen.toBigDecimal(value).setScale(0, RoundingMode.HALF_UP).longValue();
 		                        result = key.toString() + " (" + euroValue + " €)";
 		                    } else {
 		                        result = key.toString();
@@ -106,27 +108,23 @@ public class BestandPieChartControl implements Listener
 						dataset.clear();
 						break;
 					}
-					double wert;
-					if (anzahl instanceof BigDecimal) {
-						wert = ((BigDecimal) anzahl).doubleValue();
-					} else {
-						wert = (Double) anzahl;
-					}
-					
+					BigDecimal wert = Zahlen.toBigDecimal(anzahl);
+
 					// Addiere Werte für das gleiche Wertpapier aus verschiedenen Depots
 					String wertpapiername = (String) x.getAttribute("wertpapiername");
-					
+
 					// Prüfe ob das Wertpapier bereits im Dataset vorhanden ist
 					try {
 						Number existingValue = dataset.getValue(wertpapiername);
 						if (existingValue != null) {
 							// Addiere zum bestehenden Wert
-							wert += existingValue.doubleValue();
+							wert = wert.add(Zahlen.toBigDecimal(existingValue));
 						}
 					} catch (Exception e) {
 						// Key existiert noch nicht, das ist in Ordnung
 					}
-					
+
+					// bindet an setValue(Comparable, Number) - der Wert bleibt BigDecimal
 					dataset.setValue(wertpapiername, wert);
 				}
 				dataset.sortByValues(SortOrder.DESCENDING);

--- a/src/de/open4me/depot/gui/control/BestandTableControl.java
+++ b/src/de/open4me/depot/gui/control/BestandTableControl.java
@@ -15,6 +15,7 @@ import de.open4me.depot.gui.menu.BestandsListMenu;
 import de.open4me.depot.gui.parts.PrintfColumn;
 import de.open4me.depot.sql.GenericObjectSQL;
 import de.open4me.depot.tools.Bestandsabfragen;
+import de.open4me.depot.tools.Zahlen;
 import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Part;
@@ -76,19 +77,15 @@ public class BestandTableControl extends AbstractControl implements Listener
 
 			@SuppressWarnings("unchecked")
 			private String gesamtDepotWert() {
-				double sum = 0.0d;
+				BigDecimal sum = BigDecimal.ZERO;
 				try {
 					for (GenericObjectSQL k: (List<GenericObjectSQL>) getItems())
 					{
-						if (k.getAttribute("wert") == null) {
+						BigDecimal wert = Zahlen.toBigDecimal(k.getAttribute("wert"));
+						if (wert == null) {
 							continue;
 						}
-						if (k.getAttribute("wert") instanceof BigDecimal) {
-							sum += ((BigDecimal) k.getAttribute("wert")).doubleValue();
-						} else {
-							sum += (Double) k.getAttribute("wert");
-
-						}
+						sum = sum.add(wert);
 					}
 				} catch (Exception e) {
 					Logger.error("Kann Gesamtdepotwert nicht berechnen",e);

--- a/src/de/open4me/depot/gui/control/BestandTableControl.java
+++ b/src/de/open4me/depot/gui/control/BestandTableControl.java
@@ -104,7 +104,7 @@ public class BestandTableControl extends AbstractControl implements Listener
 		bestandsList.addColumn(Settings.i18n().tr("Depot"), "bezeichnung");
 		bestandsList.addColumn(Settings.i18n().tr("WKN"),"wkn");
 		bestandsList.addColumn(Settings.i18n().tr("Name"),"wertpapiername");
-		bestandsList.addColumn(new PrintfColumn(Settings.i18n().tr("Anzahl"), "anzahl",	"%,.5f", "anzahl"));
+		bestandsList.addColumn(new PrintfColumn(Settings.i18n().tr("Anzahl"), "anzahl",	"%,.8f", "anzahl"));
 		bestandsList.addColumn(new PrintfColumn(Settings.i18n().tr("Kurs"), "kurs", "%,.6f %s", "kurs", "kursw"));
 		bestandsList.addColumn(new PrintfColumn(Settings.i18n().tr("Wert"), "wert", "%,.2f %s", "wert", "wertw"));
 		bestandsList.addColumn(Settings.i18n().tr("Bewertungsdatum"),"bewertungszeitpunkt", new DateFormatter(Settings.DATEFORMAT));

--- a/src/de/open4me/depot/gui/control/BewertungsControl.java
+++ b/src/de/open4me/depot/gui/control/BewertungsControl.java
@@ -119,7 +119,7 @@ public class BewertungsControl extends AbstractControl {
 		wertList.addColumn(Settings.i18n().tr("Name"),"wertpapiername");
 		wertList.addColumn(Settings.i18n().tr("ISIN"),"isin");
 		wertList.addColumn(Settings.i18n().tr("WKN"),"wkn");
-		wertList.addColumn(new PrintfColumn(Settings.i18n().tr("Anzahl"), "anzahl",	"%,.5f", "anzahl"));
+		wertList.addColumn(new PrintfColumn(Settings.i18n().tr("Anzahl"), "anzahl",	"%,.8f", "anzahl"));
 		wertList.addColumn(new PrintfColumn(Settings.i18n().tr("Einstandspreis"), "einstand", "%,.2f %s", "einstand", "währung"));
 		wertList.addColumn(new PrintfColumn(Settings.i18n().tr("Verkaufserlöse"), "erloese", "%,.2f %s", "erloese", "währung"));
 		wertList.addColumn(new PrintfColumn(Settings.i18n().tr("Aktueller Wert"), "wert", "%,.2f %s", "wert", "währung"));

--- a/src/de/open4me/depot/gui/control/BewertungsControl.java
+++ b/src/de/open4me/depot/gui/control/BewertungsControl.java
@@ -4,7 +4,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.swt.widgets.Event;
@@ -17,7 +16,6 @@ import de.open4me.depot.gui.parts.PrintfColumn;
 import de.open4me.depot.sql.GenericObjectHashMap;
 import de.open4me.depot.sql.GenericObjectSQL;
 import de.open4me.depot.sql.SQLUtils;
-import de.open4me.depot.tools.Bestandsabfragen;
 import de.open4me.depot.tools.WertBerechnung;
 import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/open4me/depot/gui/control/OrderListControl.java
+++ b/src/de/open4me/depot/gui/control/OrderListControl.java
@@ -27,7 +27,6 @@ import de.willuhn.jameica.gui.formatter.DateFormatter;
 import de.willuhn.jameica.gui.formatter.TableFormatter;
 import de.willuhn.jameica.gui.input.DateInput;
 import de.willuhn.jameica.gui.input.SelectInput;
-import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.gui.util.Color;
 import de.willuhn.jameica.gui.util.Container;

--- a/src/de/open4me/depot/gui/control/OrderListControl.java
+++ b/src/de/open4me/depot/gui/control/OrderListControl.java
@@ -76,7 +76,7 @@ public class OrderListControl extends AbstractControl
 		orderList.addColumn(Settings.i18n().tr("Depot"), "bezeichnung");
 		orderList.addColumn(Settings.i18n().tr("WKN"),"wkn");
 		orderList.addColumn(Settings.i18n().tr("Wertpapiername"),"wertpapiername");
-		orderList.addColumn(new PrintfColumn(Settings.i18n().tr("Anzahl"), "anzahl",	"%,.5f", "anzahl"));
+		orderList.addColumn(new PrintfColumn(Settings.i18n().tr("Anzahl"), "anzahl",	"%,.8f", "anzahl"));
 		orderList.addColumn(new PrintfColumn(Settings.i18n().tr("Kurs"), "kurs", "%,.6f %s", "kurs", "kursw"));
 		orderList.addColumn(new PrintfColumn(Settings.i18n().tr("Kosten"), "kosten", "%,.2f %s", "kosten", "kostenw"));
 		orderList.addColumn(new PrintfColumn(Settings.i18n().tr("Gebühren"), "transaktionskosten", "%,.2f %s", "transaktionskosten", "transaktionskostenw"));

--- a/src/de/open4me/depot/gui/control/UmsatzEditorControl.java
+++ b/src/de/open4me/depot/gui/control/UmsatzEditorControl.java
@@ -20,10 +20,10 @@ import de.open4me.depot.sql.SQLUtils;
 import de.open4me.depot.tools.InconsistencyData;
 import de.open4me.depot.tools.UmsatzHelper;
 import de.open4me.depot.tools.VarDecimalFormat;
+import de.open4me.depot.tools.Zahlen;
 import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Part;
-import de.willuhn.jameica.gui.input.AbstractInput;
 import de.willuhn.jameica.gui.input.CheckboxInput;
 import de.willuhn.jameica.gui.input.DateInput;
 import de.willuhn.jameica.gui.input.DecimalInput;
@@ -37,7 +37,7 @@ import de.willuhn.util.ApplicationException;
 public class UmsatzEditorControl extends AbstractControl
 {
 
-	private Input betrag                       = null;
+	private DecimalInput betrag                = null;
 	private SelectInput aktion;
 	private SelectInput wp;
 	private DateInput datum;
@@ -47,7 +47,7 @@ public class UmsatzEditorControl extends AbstractControl
 	private DecimalInput gesamt;
 	private DecimalInput kurswert;
 	private CheckboxInput kurswertberechnen;
-	private AbstractInput transaktionskosten;
+	private DecimalInput transaktionskosten;
 	private DecimalInput steuern;
 	private Umsatz umsatz = null;
 	private Input kommentar;
@@ -72,9 +72,9 @@ public class UmsatzEditorControl extends AbstractControl
 		getAnzahl().setValue(umsatz.getAnzahl());
 		getEinzelkurs().setValue(umsatz.getKurs());
 		getDate().setValue(umsatz.getBuchungsdatum());
-		getSteuern().setValue((umsatz.getSteuern() != null) ? umsatz.getSteuern() : 0.0d);
-		getTransaktionskosten().setValue((umsatz.getTransaktionsgebuehren() != null) ? umsatz.getTransaktionsgebuehren()  : 0.0d);
-		getKurswert().setValue(Math.abs(umsatz.getKosten().doubleValue()));
+		getSteuern().setValue((umsatz.getSteuern() != null) ? umsatz.getSteuern() : BigDecimal.ZERO);
+		getTransaktionskosten().setValue((umsatz.getTransaktionsgebuehren() != null) ? umsatz.getTransaktionsgebuehren()  : BigDecimal.ZERO);
+		getKurswert().setValue(umsatz.getKosten().abs());
 		getKommentar().setValue(umsatz.getKommentar());
 		
 		String id = umsatz.getWPid().toString();
@@ -113,12 +113,13 @@ public class UmsatzEditorControl extends AbstractControl
 	 * @return Eingabe-Feld.
 	 * @throws RemoteException
 	 */
-	public Input getAnzahl() throws RemoteException
+	public DecimalInput getAnzahl() throws RemoteException
 	{
 		if (betrag != null)
 			return betrag;
-		double d = Double.NaN;
-		betrag = new DecimalInput(d, new VarDecimalFormat(2, 6));
+		// 8 statt 6 optionale Nachkommastellen: Stueckzahlen liegen als
+		// decimal(20,10) in der Datenbank, die Anzeige darf nicht frueher runden.
+		betrag = new DecimalInput((Number) null, new VarDecimalFormat(2, 8));
 		betrag.setMandatory(true);
 		betrag.addListener(new Listener() {
 
@@ -132,6 +133,31 @@ public class UmsatzEditorControl extends AbstractControl
 		return betrag;
 	}
 
+	/**
+	 * Liest den Wert eines Eingabefeldes als BigDecimal.
+	 *
+	 * Bewusst über {@link DecimalInput#getNumber()} statt getValue():
+	 * getValue() wandelt intern immer nach Double und wäre verlustbehaftet.
+	 * Dank {@link VarDecimalFormat} (setParseBigDecimal) liefert getNumber()
+	 * bereits einen BigDecimal; {@link Zahlen#toBigDecimal(Object)} deckt nur
+	 * Alt-/Sonderfälle ab.
+	 *
+	 * @return Wert oder null, wenn das Feld leer bzw. nicht lesbar ist
+	 */
+	private static BigDecimal toDecimal(DecimalInput input) {
+		Number n = input.getNumber();
+		if (n == null) {
+			return null;
+		}
+		// NaN/Infinity kaeme aus einem leeren bzw. kaputten Feld und liesse sich
+		// nicht in einen BigDecimal ueberfuehren - das gilt als "kein Wert".
+		double d = n.doubleValue();
+		if (Double.isNaN(d) || Double.isInfinite(d)) {
+			return null;
+		}
+		return Zahlen.toBigDecimal(n);
+	}
+
 	protected void calc()  {
 		try {
 			if ((Boolean) getCBKurswertBerechnen().getValue()) {
@@ -140,29 +166,33 @@ public class UmsatzEditorControl extends AbstractControl
 			} else {
 				getKurswert().setEnabled(true);
 			}
-			getGesamtSumme().setValue(Double.NaN);
-			if (getEinzelkurs().getValue() == null || getAnzahl().getValue() == null) {
+			getGesamtSumme().setValue(null);
+			BigDecimal anzahl = toDecimal(getAnzahl());
+			BigDecimal kurs = toDecimal(getEinzelkurs());
+			if (kurs == null || anzahl == null) {
 				return;
 			}
-			if ((Double) getAnzahl().getValue() <=0 || ((Double) getEinzelkurs().getValue() < 0)) {
+			if (anzahl.signum() <= 0 || kurs.signum() < 0) {
 				return;
 			}
 			if ((Boolean) getCBKurswertBerechnen().getValue()) {
-				Double d = (Double) getAnzahl().getValue() * (Double) getEinzelkurs().getValue();
-				getKurswert().setValue(d);
-			} else {
+				getKurswert().setValue(anzahl.multiply(kurs));
 			}
-			
-			int faktor = -1;
-			if (getAktionAuswahl().getValue().equals(DepotAktion.VERKAUF) || getAktionAuswahl().getValue().equals(DepotAktion.AUSBUCHUNG)) {
-				faktor = 1;
+
+			BigDecimal kurswert = toDecimal(getKurswert());
+			if (kurswert == null) {
+				return;
 			}
-			Double d = faktor * (Double) getKurswert().getValue();
-			if (getTransaktionskosten().getValue() != null) {
-				d = d  - (Double) getTransaktionskosten().getValue();
+			boolean istErloes = getAktionAuswahl().getValue().equals(DepotAktion.VERKAUF)
+					|| getAktionAuswahl().getValue().equals(DepotAktion.AUSBUCHUNG);
+			BigDecimal d = istErloes ? kurswert : kurswert.negate();
+			BigDecimal kosten = toDecimal(getTransaktionskosten());
+			if (kosten != null) {
+				d = d.subtract(kosten);
 			}
-			if (getSteuern().getValue() != null) {
-				d = d  - (Double) getSteuern().getValue();
+			BigDecimal st = toDecimal(getSteuern());
+			if (st != null) {
+				d = d.subtract(st);
 			}
 			getGesamtSumme().setValue(d);
 		} catch (RemoteException re) {
@@ -176,12 +206,11 @@ public class UmsatzEditorControl extends AbstractControl
 	 * @return Eingabe-Feld.
 	 * @throws RemoteException
 	 */
-	public Input getEinzelkurs() throws RemoteException
+	public DecimalInput getEinzelkurs() throws RemoteException
 	{
 		if (einzelkurs != null)
 			return einzelkurs;
-		double d = Double.NaN;
-		einzelkurs = new DecimalInput(d, new VarDecimalFormat(2, 6));
+		einzelkurs = new DecimalInput((Number) null, new VarDecimalFormat(2, 6));
 		einzelkurs.setMandatory(true);
 		einzelkurs.addListener(new Listener() {
 
@@ -242,22 +271,36 @@ public class UmsatzEditorControl extends AbstractControl
 
 
 	public void handleStore() throws RemoteException, ApplicationException {
-		int faktor = -1;
-		if (getAktionAuswahl().getValue().equals(DepotAktion.VERKAUF) || getAktionAuswahl().getValue().equals(DepotAktion.AUSBUCHUNG)) {
-			faktor = 1;
-		}
-		if (getEinzelkurs().getValue() == null || getAnzahl().getValue() == null || getDate().getValue() ==null) {
+		boolean istErloes = getAktionAuswahl().getValue().equals(DepotAktion.VERKAUF)
+				|| getAktionAuswahl().getValue().equals(DepotAktion.AUSBUCHUNG);
+		BigDecimal anzahl = toDecimal(getAnzahl());
+		BigDecimal kurs = toDecimal(getEinzelkurs());
+		if (kurs == null || anzahl == null || getDate().getValue() ==null) {
 			throw new ApplicationException("Bitte vervollständigen Sie die Eingabe.");
 		}
-		if ((Double) getAnzahl().getValue() <=0 || ((Double) getEinzelkurs().getValue() < 0)) {
+		if (anzahl.signum() <= 0 || kurs.signum() < 0) {
 			throw new ApplicationException("Die Anzahl und der Kurs müssen positiv sein.");
+		}
+		BigDecimal kurswert = toDecimal(getKurswert());
+		if (kurswert == null) {
+			throw new ApplicationException("Bitte vervollständigen Sie die Eingabe.");
+		}
+		// Leere Gebühren-/Steuerfelder wie 0 behandeln (so sind sie auch vorbelegt)
+		BigDecimal gebuehren = toDecimal(getTransaktionskosten());
+		if (gebuehren == null) {
+			gebuehren = BigDecimal.ZERO;
+		}
+		BigDecimal st = toDecimal(getSteuern());
+		if (st == null) {
+			st = BigDecimal.ZERO;
 		}
 		if (umsatz == null) {
 			umsatz = (Umsatz) Settings.getDBService().createObject(Umsatz.class,null);
 			umsatz.setBuchungsinformationen("");
-			umsatz.setOrderid("" + (((GenericObjectSQL) getWertpapiere().getValue()).getID() + getAktionAuswahl().getValue().toString() +
-						getAnzahl().getValue().toString() + getEinzelkurs().getValue().toString() + "EUR" + getDate().getValue()
-						).hashCode());
+			umsatz.setOrderid(Zahlen.berechneManuelleOrderId(
+						((GenericObjectSQL) getWertpapiere().getValue()).getID(),
+						getAktionAuswahl().getValue().toString(),
+						anzahl, kurs, "EUR", (Date) getDate().getValue()));
 			umsatz.setKursW("EUR");
 			umsatz.setKostenW("EUR");
 			umsatz.setSteuernW("EUR");
@@ -267,12 +310,12 @@ public class UmsatzEditorControl extends AbstractControl
 		umsatz.setKontoid(Integer.parseInt(k.getID()));
 		umsatz.setWPid(((GenericObjectSQL) getWertpapiere().getValue()).getID());
 		umsatz.setAktion((DepotAktion) getAktionAuswahl().getValue());
-		umsatz.setAnzahl(BigDecimal.valueOf((Double) getAnzahl().getValue()));
-		umsatz.setKurs(BigDecimal.valueOf((Double) getEinzelkurs().getValue()));
-		umsatz.setKosten(BigDecimal.valueOf(faktor * (Double) getKurswert().getValue()));
+		umsatz.setAnzahl(anzahl);
+		umsatz.setKurs(kurs);
+		umsatz.setKosten(istErloes ? kurswert : kurswert.negate());
 		umsatz.setBuchungsdatum((Date) getDate().getValue());
-		umsatz.setSteuern(BigDecimal.valueOf((Double) getSteuern().getValue()));
-		umsatz.setTransaktionsgebuehren(BigDecimal.valueOf((Double) getTransaktionskosten().getValue()));
+		umsatz.setSteuern(st);
+		umsatz.setTransaktionsgebuehren(gebuehren);
 		umsatz.setKommentar((String)getKommentar().getValue());
 		umsatz.store();
 		
@@ -300,8 +343,7 @@ public class UmsatzEditorControl extends AbstractControl
 	public DecimalInput getGesamtSumme() {
 		if (gesamt != null)
 			return gesamt;
-		double d = Double.NaN;
-		gesamt = new DecimalInput(d, new VarDecimalFormat(2));
+		gesamt = new DecimalInput((Number) null, new VarDecimalFormat(2));
 		gesamt.setMandatory(true);
 		gesamt.setEnabled(false);
 		return gesamt;
@@ -316,20 +358,18 @@ public class UmsatzEditorControl extends AbstractControl
 		return kommentar;
 	}
 
-	public Input getKurswert() {
+	public DecimalInput getKurswert() {
 		if (kurswert != null)
 			return kurswert;
-		double d = Double.NaN;
-		kurswert = new DecimalInput(d, new VarDecimalFormat(2, 6));
+		kurswert = new DecimalInput((Number) null, new VarDecimalFormat(2, 6));
 		kurswert.setMandatory(true);
 		return kurswert;
 	}
 
-	public Input getTransaktionskosten() {
+	public DecimalInput getTransaktionskosten() {
 		if (transaktionskosten != null)
 			return transaktionskosten;
-		double d = Double.valueOf("0");
-		transaktionskosten = new DecimalInput(d, new VarDecimalFormat(2, 6));
+		transaktionskosten = new DecimalInput(BigDecimal.ZERO, new VarDecimalFormat(2, 6));
 		transaktionskosten.setMandatory(true);
 		transaktionskosten.addListener(new Listener() {
 
@@ -356,11 +396,10 @@ public class UmsatzEditorControl extends AbstractControl
 		return kurswertberechnen;
 	}
 
-	public Input getSteuern() {
+	public DecimalInput getSteuern() {
 		if (steuern != null)
 			return steuern;
-		double d = Double.valueOf("0");
-		steuern = new DecimalInput(d, new VarDecimalFormat(2, 6));
+		steuern = new DecimalInput(BigDecimal.ZERO, new VarDecimalFormat(2, 6));
 		steuern.setMandatory(true);
 		steuern.addListener(new Listener() {
 

--- a/src/de/open4me/depot/gui/control/UmsatzEditorControl.java
+++ b/src/de/open4me/depot/gui/control/UmsatzEditorControl.java
@@ -118,7 +118,7 @@ public class UmsatzEditorControl extends AbstractControl
 		if (betrag != null)
 			return betrag;
 		double d = Double.NaN;
-		betrag = new DecimalInput(d, new VarDecimalFormat(2, 3));
+		betrag = new DecimalInput(d, new VarDecimalFormat(2, 6));
 		betrag.setMandatory(true);
 		betrag.addListener(new Listener() {
 
@@ -181,7 +181,7 @@ public class UmsatzEditorControl extends AbstractControl
 		if (einzelkurs != null)
 			return einzelkurs;
 		double d = Double.NaN;
-		einzelkurs = new DecimalInput(d, new VarDecimalFormat(2, 3));
+		einzelkurs = new DecimalInput(d, new VarDecimalFormat(2, 6));
 		einzelkurs.setMandatory(true);
 		einzelkurs.addListener(new Listener() {
 
@@ -320,7 +320,7 @@ public class UmsatzEditorControl extends AbstractControl
 		if (kurswert != null)
 			return kurswert;
 		double d = Double.NaN;
-		kurswert = new DecimalInput(d, new VarDecimalFormat(2, 3));
+		kurswert = new DecimalInput(d, new VarDecimalFormat(2, 6));
 		kurswert.setMandatory(true);
 		return kurswert;
 	}
@@ -329,7 +329,7 @@ public class UmsatzEditorControl extends AbstractControl
 		if (transaktionskosten != null)
 			return transaktionskosten;
 		double d = Double.valueOf("0");
-		transaktionskosten = new DecimalInput(d, new VarDecimalFormat(2, 3));
+		transaktionskosten = new DecimalInput(d, new VarDecimalFormat(2, 6));
 		transaktionskosten.setMandatory(true);
 		transaktionskosten.addListener(new Listener() {
 
@@ -360,7 +360,7 @@ public class UmsatzEditorControl extends AbstractControl
 		if (steuern != null)
 			return steuern;
 		double d = Double.valueOf("0");
-		steuern = new DecimalInput(d, new VarDecimalFormat(2, 3));
+		steuern = new DecimalInput(d, new VarDecimalFormat(2, 6));
 		steuern.setMandatory(true);
 		steuern.addListener(new Listener() {
 

--- a/src/de/open4me/depot/hbcijobs/HBCIDepotBestandJob.java
+++ b/src/de/open4me/depot/hbcijobs/HBCIDepotBestandJob.java
@@ -144,8 +144,8 @@ public class HBCIDepotBestandJob extends AbstractHBCIJob
 					}
 				}
 				subtotal = subtotal.add(g.depotwert.getValue());
-				Utils.addBestand(Utils.getORcreateWKN(g.wkn, g.isin, g.name), konto, anzahl.doubleValue(), g.price.getValue().doubleValue(), 
-						g.price.getCurr(), g.depotwert.getValue().doubleValue(),  g.depotwert.getCurr(), depot.timestamp, g.timestamp_price);
+				Utils.addBestand(Utils.getORcreateWKN(g.wkn, g.isin, g.name), konto, anzahl, g.price.getValue(),
+						g.price.getCurr(), g.depotwert.getValue(),  g.depotwert.getCurr(), depot.timestamp, g.timestamp_price);
 			}
 			total = total.add((depot.total != null) ? depot.total.getValue() : subtotal); // Bei der DKB ist depot.total == null, wenn das Depot leer ist
 		}

--- a/src/de/open4me/depot/hbcijobs/HBCIDepotUmsatzJob.java
+++ b/src/de/open4me/depot/hbcijobs/HBCIDepotUmsatzJob.java
@@ -1,5 +1,7 @@
 package de.open4me.depot.hbcijobs;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -208,26 +210,27 @@ public class HBCIDepotUmsatzJob extends AbstractHBCIJob
 					String orderid = i.wkn + i.isin + aktion + t.datum + t.anzahl + t.betrag; 
 					try {
 						String waehrung = "";
-						double gesamtbetrag = 0.0d;
-						double einzelbetrag = 0.0d;
+						BigDecimal gesamtbetrag = BigDecimal.ZERO;
+						BigDecimal einzelbetrag = BigDecimal.ZERO;
 						if (t.betrag != null) {
-							gesamtbetrag = t.betrag.getValue().doubleValue();
+							gesamtbetrag = t.betrag.getValue();
 							if ("BIWBDE33XXX".equals(konto.getBic()) || "10130800".equals(konto.getBLZ()))  {
 								// Hack für FlatEx
-								gesamtbetrag = -gesamtbetrag;
+								gesamtbetrag = gesamtbetrag.negate();
 							}
 							waehrung = t.betrag.getCurr();
-							einzelbetrag = Math.abs(gesamtbetrag) / t.anzahl.getValue().doubleValue();
+							// Scale 8 passend zur Spalte kurs decimal(20,8)
+							einzelbetrag = gesamtbetrag.abs().divide(t.anzahl.getValue(), 8, RoundingMode.HALF_UP);
 						}
-						Umsatz u = Utils.addUmsatz(konto.getID(), 
+						Umsatz u = Utils.addUmsatz(konto.getID(),
 								Utils.getORcreateWKN(i.wkn, i.isin, i.name), aktion,
 								i.toString() + "\n" + t.toString(),
-								t.anzahl.getValue().doubleValue(),
+								t.anzahl.getValue(),
 								einzelbetrag, waehrung,
 								gesamtbetrag, waehrung,
 								t.datum,
 								String.valueOf(orderid.hashCode()),
-								"",0.0d, "EUR", 0.0d, "EUR"
+								"", BigDecimal.ZERO, "EUR", BigDecimal.ZERO, "EUR"
 								);
 						UmsatzHelper.storeUmsatzInHibiscus(u);
 					} catch (RemoteException e) {

--- a/src/de/open4me/depot/messageconsumer/PortfolioMessageConsumer.java
+++ b/src/de/open4me/depot/messageconsumer/PortfolioMessageConsumer.java
@@ -6,11 +6,10 @@ import java.util.Map;
 
 import de.willuhn.jameica.hbci.rmi.Konto;
 import de.open4me.depot.abruf.utils.Utils;
+import de.open4me.depot.tools.Zahlen;
 import de.willuhn.jameica.messaging.Message;
 import de.willuhn.jameica.messaging.MessageConsumer;
 import de.willuhn.jameica.messaging.QueryMessage;
-import de.willuhn.jameica.hbci.rmi.Konto;
-import de.willuhn.util.ApplicationException;
 
 
 public class PortfolioMessageConsumer implements MessageConsumer
@@ -43,10 +42,10 @@ public class PortfolioMessageConsumer implements MessageConsumer
     	Utils.addBestand(
     			Utils.getORcreateWKN((String) h.get("wkn"),(String)h.get("isin"),(String)h.get("name")),
     			(Konto) h.get("konto"),
-    			(Double) h.get("anzahl"),
-    			(Double) h.get("kurs"),
+    			Zahlen.toBigDecimal(h.get("anzahl")),
+    			Zahlen.toBigDecimal(h.get("kurs")),
     			(String) h.get("kursw"),
-    			(Double) h.get("wert"),
+    			Zahlen.toBigDecimal(h.get("wert")),
     			(String) h.get("wertw"),
     			(Date) h.get("datum"),
     			(Date) h.get("bewertungszeitpunkt"));

--- a/src/de/open4me/depot/messageconsumer/TransactionMessageConsumer.java
+++ b/src/de/open4me/depot/messageconsumer/TransactionMessageConsumer.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import de.open4me.depot.abruf.utils.Utils;
 import de.open4me.depot.datenobj.rmi.Umsatz;
+import de.open4me.depot.tools.Zahlen;
 import de.open4me.depot.tools.UmsatzHelper;
 import de.willuhn.jameica.messaging.Message;
 import de.willuhn.jameica.messaging.MessageConsumer;
@@ -45,17 +46,17 @@ public class TransactionMessageConsumer implements MessageConsumer {
     			wpid, 
     			(String) t.get("aktion"),
     			"", 
-    			(Double) t.get("anzahl"),
-    			(Double) t.get("kurs"),
-    			(String) t.get("kursw"), 
-    			(Double) t.get("kosten"),
+    			Zahlen.toBigDecimal(t.get("anzahl")),
+    			Zahlen.toBigDecimal(t.get("kurs")),
+    			(String) t.get("kursw"),
+    			Zahlen.toBigDecimal(t.get("kosten")),
     			(String) t.get("kostenw"), 
     			(Date) t.get("datetime"),
     			(String) t.get("orderid"),
     			"",
-    			(Double) t.get("gebuehren"),
-    			(String) t.get("gebuehrenw"), 
-    			(Double) t.get("steuern"),
+    			Zahlen.optionalerBetrag(t.get("gebuehren")),
+    			(String) t.get("gebuehrenw"),
+    			Zahlen.optionalerBetrag(t.get("steuern")),
     			(String) t.get("steuernw"));
     	UmsatzHelper.storeUmsatzInHibiscus(u);
     } catch (Exception e) {

--- a/src/de/open4me/depot/search/OrderSearchProvider.java
+++ b/src/de/open4me/depot/search/OrderSearchProvider.java
@@ -70,7 +70,7 @@ public class OrderSearchProvider implements SearchProvider {
 		public String getName() {
 			try {
 				DateFormat df = new SimpleDateFormat("dd.MM.yyyy");
-				VarDecimalFormat kf = new VarDecimalFormat(5);
+				VarDecimalFormat kf = new VarDecimalFormat(5, 3);
 				return df.format((Date) this.order.getAttribute("buchungsdatum")) + ": "
 						+ this.order.getAttribute("aktion") + " " + kf.format(this.order.getAttribute("anzahl"))
 						+ " Stück " + (String) this.order.getAttribute("nicename") + ", Kurs: "

--- a/src/de/open4me/depot/sql/SQLChange.java
+++ b/src/de/open4me/depot/sql/SQLChange.java
@@ -24,6 +24,17 @@ public class SQLChange {
 	}
 
 	public static List<SQLChange> getChangesSinceVersion(int currentversion) {
+		return getChangesSinceVersion(currentversion, false);
+	}
+
+	/**
+	 * Liefert die Changesets seit der übergebenen Version.
+	 * Ab Version 19 unterscheiden sich die Statements je nach Datenbank,
+	 * da H2 2.x kein "MODIFY COLUMN" mehr versteht und MySQL kein "ALTER COLUMN &lt;typ&gt;".
+	 * @param currentversion aktuelle dbversion
+	 * @param mysql true für MySQL/MariaDB, false für H2 (Hibiscus-Standard)
+	 */
+	public static List<SQLChange> getChangesSinceVersion(int currentversion, boolean mysql) {
 		ArrayList<SQLChange> liste = new ArrayList<SQLChange>();
 		if (currentversion < 3) {
 
@@ -209,9 +220,44 @@ public class SQLChange {
 					"ALTER TABLE depotviewer_umsaetze MODIFY  COLUMN  `aktion` varchar(30) NOT NULL;"));
 		}
 		if (currentversion < 18) {
-			liste.add(new SQLChange(18, 	
+			liste.add(new SQLChange(18,
 					"create index idxKurseId on depotviewer_kurse(id);"
 					));
+		}
+		if (currentversion < 19) {
+			// Erweiterung aller Geld-/Kurs-Spalten von decimal(20,6) bzw. decimal(10,5) auf decimal(20,8)
+			if (mysql) {
+				liste.add(new SQLChange(19,
+						"ALTER TABLE depotviewer_umsaetze MODIFY  COLUMN  `kurs` decimal(20,8);",
+						"ALTER TABLE depotviewer_umsaetze MODIFY  COLUMN  `kosten` decimal(20,8);",
+						"ALTER TABLE depotviewer_umsaetze MODIFY  COLUMN  `transaktionskosten` decimal(20,8);",
+						"ALTER TABLE depotviewer_umsaetze MODIFY  COLUMN  `steuern` decimal(20,8);",
+
+						"ALTER TABLE depotviewer_bestand MODIFY  COLUMN  `kurs` decimal(20,8);",
+						"ALTER TABLE depotviewer_bestand MODIFY  COLUMN  `wert` decimal(20,8);",
+
+						"ALTER TABLE depotviewer_kurse MODIFY  COLUMN  `kurs` decimal(20,8);",
+						"ALTER TABLE depotviewer_kurse MODIFY  COLUMN  `kursperf` decimal(20,8);",
+
+						"ALTER TABLE depotviewer_kursevent MODIFY  COLUMN  `value` decimal(20,8);"
+						));
+			} else {
+				liste.add(new SQLChange(19,
+						"ALTER TABLE depotviewer_umsaetze ALTER COLUMN kurs decimal(20,8);",
+						"ALTER TABLE depotviewer_umsaetze ALTER COLUMN kosten decimal(20,8);",
+						"ALTER TABLE depotviewer_umsaetze ALTER COLUMN transaktionskosten decimal(20,8);",
+						"ALTER TABLE depotviewer_umsaetze ALTER COLUMN steuern decimal(20,8);",
+
+						"ALTER TABLE depotviewer_bestand ALTER COLUMN kurs decimal(20,8);",
+						"ALTER TABLE depotviewer_bestand ALTER COLUMN wert decimal(20,8);",
+
+						"ALTER TABLE depotviewer_kurse ALTER COLUMN kurs decimal(20,8);",
+						"ALTER TABLE depotviewer_kurse ALTER COLUMN kursperf decimal(20,8);",
+
+						// "value" ist ab H2 2.x ein Schlüsselwort und muss gequotet werden
+						"ALTER TABLE depotviewer_kursevent ALTER COLUMN \"VALUE\" decimal(20,8);"
+						));
+			}
 		}
 
 //		liste.add(new SQLChange(currentversion,

--- a/src/de/open4me/depot/sql/SQLUtils.java
+++ b/src/de/open4me/depot/sql/SQLUtils.java
@@ -157,7 +157,8 @@ public class SQLUtils {
 
 
 	public static void checkforupdates() throws ApplicationException {
-		List<SQLChange> liste = SQLChange.getChangesSinceVersion(getCurrentDBVersion());
+		int currentversion = getCurrentDBVersion(); // initialisiert nebenbei den Treiber
+		List<SQLChange> liste = SQLChange.getChangesSinceVersion(currentversion, driver instanceof DBSupportMySqlImpl);
 		try(Connection conn = getConnection();) {
 			for (SQLChange changeset : liste) {
 				Logger.info("Depot-Viewer: Updating DB to " + changeset.getVersion());

--- a/src/de/open4me/depot/tools/Bestandsabfragen.java
+++ b/src/de/open4me/depot/tools/Bestandsabfragen.java
@@ -120,6 +120,10 @@ public class Bestandsabfragen implements AccountBalanceProvider {
 
 		    int numdays = (int)Utils.getDifferenceDays(start, end) + 1;
 		    BigDecimal[] wpTagWerte = new BigDecimal[numdays]; // für das aktuelle Wertpapier werden hier Anzahl * Kurs für jeden Tag verwaltet
+		    // Tagessummen über alle Wertpapiere exakt aufaddieren; erst zum Schluss
+		    // nach double wandeln, da Value (Hibiscus) nur double kennt
+		    BigDecimal[] tagesSummen = new BigDecimal[numdays];
+		    Arrays.fill(tagesSummen, BigDecimal.ZERO);
 
 		    // Ausgabe vorbereiten
 		    data = new ArrayList<Value>(numdays);
@@ -182,9 +186,13 @@ public class Bestandsabfragen implements AccountBalanceProvider {
 
 				// Werte des Wertpapiers auf Ergebnis summieren
 				for (tagIdx = 0; tagIdx < numdays; ++tagIdx) {
-			    	Value v = data.get(tagIdx);
-			    	v.setValue(v.getValue() + wpTagWerte[tagIdx].doubleValue());
+			    	tagesSummen[tagIdx] = tagesSummen[tagIdx].add(wpTagWerte[tagIdx]);
 			    }
+			}
+
+			// Exakte Tagessummen an die (double-basierte) Hibiscus-API übergeben
+			for (int tagIdx = 0; tagIdx < numdays; ++tagIdx) {
+				data.get(tagIdx).setValue(tagesSummen[tagIdx].doubleValue());
 			}
 		} catch (Exception e) {
 			Logger.error("Fehler beim der Ermittlung der Depotsalden des DeportViewers", e);

--- a/src/de/open4me/depot/tools/Bestandspruefung.java
+++ b/src/de/open4me/depot/tools/Bestandspruefung.java
@@ -136,7 +136,7 @@ public class Bestandspruefung {
 			}
 			
 			// Bestand hinzufügen
-			Utils.addBestand(position.getKey().toString(), k, position.getValue().doubleValue(), kurs.doubleValue(), kursW, wert.doubleValue(), wertW, new Date(), bewertung);
+			Utils.addBestand(position.getKey().toString(), k, position.getValue(), kurs, kursW, wert, wertW, new Date(), bewertung);
 		}
 		k.setSaldo(saldo.doubleValue());
 		k.store();

--- a/src/de/open4me/depot/tools/UmsatzHelper.java
+++ b/src/de/open4me/depot/tools/UmsatzHelper.java
@@ -38,7 +38,7 @@ public class UmsatzHelper {
 	 */
 	public static void storeUmsatzInHibiscus(Umsatz u) throws RemoteException, ApplicationException {		
 		VarDecimalFormat df = new VarDecimalFormat(2);
-		VarDecimalFormat kf = new VarDecimalFormat(5);
+		VarDecimalFormat kf = new VarDecimalFormat(5, 3);
 		
 		// abfragen, ob Umsatz bereits existiert anhand der meta-depotviewer_id
 		de.willuhn.jameica.hbci.rmi.Umsatz hu = getHibiscusUmsatzByDepotViewerId(u.getID());

--- a/src/de/open4me/depot/tools/UmsatzeAusBestandsAenderung.java
+++ b/src/de/open4me/depot/tools/UmsatzeAusBestandsAenderung.java
@@ -95,14 +95,14 @@ public class UmsatzeAusBestandsAenderung {
 						"" + wpid,
 						(isKauf) ? DepotAktion.KAUF.internal() : DepotAktion.VERKAUF.internal(),
 								"",
-								diff.abs().doubleValue(),
-								((BigDecimal) ref.getAttribute("kurs")).doubleValue(),
+								diff.abs(),
+								(BigDecimal) ref.getAttribute("kurs"),
 								(String) ref.getAttribute("kursw"),
-								(isKauf) ? ((BigDecimal) ref.getAttribute("wert")).negate().doubleValue() : ((BigDecimal) ref.getAttribute("wert")).doubleValue(),
+								(isKauf) ? ((BigDecimal) ref.getAttribute("wert")).negate() : (BigDecimal) ref.getAttribute("wert"),
 										(String) ref.getAttribute("kursw"),
 										(Date) ref.getAttribute("datum"),
 										null, "aus Bestandsänderungen generierte Schätzung"
-										,0.0d, "EUR", 0.0d, "EUR");
+										, BigDecimal.ZERO, "EUR", BigDecimal.ZERO, "EUR");
 				UmsatzHelper.storeUmsatzInHibiscus(u);
 			}
 		} catch (Exception e) {

--- a/src/de/open4me/depot/tools/VarDecimalFormat.java
+++ b/src/de/open4me/depot/tools/VarDecimalFormat.java
@@ -32,6 +32,10 @@ public class VarDecimalFormat extends DecimalFormat
 		super("###,###,##0." + nullen(nachkommastellen) + StringUtils.repeat('#', extranachkommastellen),new DecimalFormatSymbols(Application.getConfig().getLocale()));
 		this.nachkommastellen = nachkommastellen;
 		setGroupingUsed(true);
+		// Geldbetraege duerfen beim Einlesen nicht ueber double laufen.
+		// Wirkt nur auf parse(), nicht auf format(). DecimalInput.getNumber()
+		// liefert dadurch BigDecimal statt Double.
+		setParseBigDecimal(true);
 	}
 
 	/**

--- a/src/de/open4me/depot/tools/Zahlen.java
+++ b/src/de/open4me/depot/tools/Zahlen.java
@@ -1,0 +1,114 @@
+package de.open4me.depot.tools;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+/**
+ * Hilfsfunktionen für die verlustfreie Umwandlung von Geldbeträgen, Kursen und
+ * Stückzahlen nach {@link BigDecimal} sowie für die Berechnung der synthetischen
+ * OrderIDs.
+ *
+ * Bewusst frei von Jameica-Abhängigkeiten, damit die Umrechnungsregeln ohne
+ * laufende Anwendung testbar bleiben (siehe {@code de.open4me.depot.tools.ZahlenTest}).
+ */
+public final class Zahlen {
+
+	private Zahlen() {
+		// nur statische Methoden
+	}
+
+	/**
+	 * Wandelt eine Zahl in deutscher Schreibweise ("1.234,56") in einen exakten
+	 * BigDecimal um.
+	 *
+	 * Loest {@code Utils.getDoubleFromZahl} ab, das dieselbe Aufgabe ueber
+	 * Double erledigt hat. Derzeit ohne Aufrufer im Produktivcode — gedacht
+	 * fuer Importquellen, die Betraege als vorformatierten Text liefern.
+	 */
+	public static BigDecimal ausDeutscherSchreibweise(String s) {
+		return new BigDecimal(s.replace(".", "").replace(",", "."));
+	}
+
+	/**
+	 * Wandelt einen beliebigen Zahlwert verlustfrei in einen BigDecimal um.
+	 *
+	 * Wird für die per {@code QueryMessage} von fremden Plugins gelieferten,
+	 * untypisierten Werte benötigt: die legen dort historisch Double ab, neuere
+	 * Sender können BigDecimal oder String liefern. Ein harter Cast auf einen
+	 * dieser Typen würde die jeweils anderen Sender brechen.
+	 *
+	 * Gilt genauso für Werte aus einem {@code GenericObjectSQL}: welchen
+	 * konkreten Number-Typ der JDBC-Treiber für eine decimal-Spalte liefert,
+	 * ist nicht garantiert und kann sich zwischen H2 und MySQL unterscheiden.
+	 *
+	 * @param o Zahlwert, darf null sein
+	 * @return exakter BigDecimal oder null
+	 */
+	public static BigDecimal toBigDecimal(Object o) {
+		if (o == null) {
+			return null;
+		}
+		if (o instanceof BigDecimal) {
+			return (BigDecimal) o;
+		}
+		// Umweg über toString() statt doubleValue(): so bleiben Long/BigInteger
+		// exakt, und bei Double entspricht es BigDecimal.valueOf(double), also
+		// der dargestellten Dezimalzahl statt der binären Expansion.
+		return new BigDecimal(o.toString());
+	}
+
+	/**
+	 * Wie {@link #toBigDecimal(Object)}, liefert aber 0 statt null.
+	 *
+	 * Gedacht für die optionalen Beträge Gebühren und Steuern: die Datenbank
+	 * führt sie als 0 und nicht als NULL — das Changeset auf dbversion 12 hat
+	 * bestehende NULL-Werte auf 0 gesetzt (siehe {@code SQLChange}). Fehlt der
+	 * Wert in einer QueryMessage, ist 0 daher die richtige Annahme.
+	 *
+	 * @param o Zahlwert, darf null sein
+	 * @return exakter BigDecimal, nie null
+	 */
+	public static BigDecimal optionalerBetrag(Object o) {
+		BigDecimal wert = toBigDecimal(o);
+		return (wert == null) ? BigDecimal.ZERO : wert;
+	}
+
+	/**
+	 * Berechnet die synthetische OrderID für importierte Umsätze, die vom
+	 * Datenlieferanten keine eigene ID mitbekommen.
+	 */
+	public static String berechneOrderId(String kontoid, String wpid, String aktion, Date date,
+			BigDecimal anzahl, BigDecimal kurs, String kursW) {
+		return "" + ("" + kontoid + wpid + aktion + date
+				+ fuerHash(anzahl) + fuerHash(kurs) + kursW).hashCode();
+	}
+
+	/**
+	 * Berechnet die synthetische OrderID für im Umsatz-Editor manuell angelegte
+	 * Umsätze.
+	 *
+	 * Feldreihenfolge und Position der Währung weichen bewusst von
+	 * {@link #berechneOrderId} ab — es ist die Formel, die der Editor schon
+	 * immer verwendet hat.
+	 */
+	public static String berechneManuelleOrderId(String wpid, String aktion,
+			BigDecimal anzahl, BigDecimal kurs, String kursW, Date date) {
+		return "" + (wpid + aktion + fuerHash(anzahl) + fuerHash(kurs) + kursW + date).hashCode();
+	}
+
+	/**
+	 * Stellt einen Betrag genau so dar, wie ihn die frühere Double-Variante in
+	 * den Hash gegeben hat.
+	 *
+	 * Der Umweg über {@link BigDecimal#doubleValue()} ist kein Versehen: anzahl
+	 * und kurs waren früher vom Typ Double, und BigDecimal.toString() liefert
+	 * eine andere Darstellung ("10" statt "10.0") und damit einen anderen Hash.
+	 * Ohne diese Umrechnung würden bereits importierte Orders nicht mehr
+	 * wiedergefunden und beim nächsten Abruf ein zweites Mal angelegt.
+	 */
+	private static String fuerHash(BigDecimal wert) {
+		// "null" entspricht dem, was die Verkettung mit einem Double-Objekt
+		// vor der Umstellung ergeben hat.
+		return (wert == null) ? "null" : Double.toString(wert.doubleValue());
+	}
+}

--- a/test/database/DataBaseCreation.java
+++ b/test/database/DataBaseCreation.java
@@ -23,7 +23,7 @@ public class DataBaseCreation {
 	public void runH2() throws ClassNotFoundException, SQLException, IOException {
 		File file = File.createTempFile("depotviewer", "test");
 		file.delete(); // Not safe, but in this case ok
-		test("org.h2.Driver","jdbc:h2:" + file.getAbsolutePath(), "", "");
+		test("org.h2.Driver","jdbc:h2:" + file.getAbsolutePath(), "", "", false);
 	}
 
 	@Test
@@ -35,7 +35,7 @@ public class DataBaseCreation {
 			reader.close();
 
 		String dbname = createTempDB("com.mysql.jdbc.Driver", "jdbc:mysql://localhost:3306/", credentail.getProperty("user"), credentail.getProperty("pwd"));
-		test("com.mysql.jdbc.Driver", "jdbc:mysql://localhost:3306/" + dbname + "?useUnicode=Yes&characterEncoding=ISO8859_1", "hibiscus", "hibiscus");
+		test("com.mysql.jdbc.Driver", "jdbc:mysql://localhost:3306/" + dbname + "?useUnicode=Yes&characterEncoding=ISO8859_1", "hibiscus", "hibiscus", true);
 	}
 
 	private String createTempDB(String classname, String jdbc, String user, String pwd) throws ClassNotFoundException, SQLException {
@@ -83,12 +83,12 @@ public class DataBaseCreation {
 		conn.commit();
 	}
 
-	public void test(String classname, String jdbc, String user, String pwd) throws ClassNotFoundException, SQLException {
+	public void test(String classname, String jdbc, String user, String pwd, boolean mysql) throws ClassNotFoundException, SQLException {
 		Class.forName(classname);
 
 
 
-		List<SQLChange> liste = SQLChange.getChangesSinceVersion(0);
+		List<SQLChange> liste = SQLChange.getChangesSinceVersion(0, mysql);
 		Connection conn = null;
 
 		conn = DriverManager.getConnection(jdbc, user, pwd);

--- a/test/database/PrecisionTest.java
+++ b/test/database/PrecisionTest.java
@@ -1,0 +1,259 @@
+package database;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.Test;
+
+import de.open4me.depot.sql.SQLChange;
+
+/**
+ * Prüft, dass Beträge, Kurse, Gebühren und Steuern mit 8 Nachkommastellen
+ * verlustfrei gespeichert und wieder ausgelesen werden (dbversion 19)
+ * und dass die Migration von dbversion 18 auf 19 bestehende Werte
+ * unverändert lässt.
+ *
+ * Hintergrund zu den H2-Verbindungsoptionen: Die produktiven Depotviewer-Tabellen
+ * wurden ursprünglich unter H2 1.x angelegt. H2 2.x akzeptiert die alten
+ * CREATE-TABLE-Statements (int(10), Spaltenname "value") nur noch mit
+ * MODE=MySQL und NON_KEYWORDS=VALUE. Der Aufbau des Alt-Schemas läuft daher mit
+ * diesen Optionen; die eigentliche v19-Migration wird anschließend über eine
+ * Verbindung im H2-Standardmodus ausgeführt — genau wie in einer produktiven
+ * Hibiscus-Installation mit H2 2.x.
+ */
+public class PrecisionTest {
+
+	private static final int OLD_VERSION = 18;
+	private static final String LEGACY_OPTS = ";MODE=MySQL;NON_KEYWORDS=VALUE";
+
+	private File dbFile() throws Exception {
+		Class.forName("org.h2.Driver");
+		File file = File.createTempFile("depotviewer_precision", "test");
+		file.delete(); // Not safe, but in this case ok (siehe DataBaseCreation)
+		file.deleteOnExit();
+		return file;
+	}
+
+	private Connection connect(File file, String opts) throws SQLException {
+		return DriverManager.getConnection("jdbc:h2:" + file.getAbsolutePath() + opts, "", "");
+	}
+
+	/**
+	 * Erzeugt eine frische Datenbank und spielt alle Changesets bis
+	 * einschließlich targetVersion ein (Integer.MAX_VALUE = alle).
+	 */
+	private Connection createDb(File file, int targetVersion, boolean mysql) throws Exception {
+		Connection conn = connect(file, LEGACY_OPTS);
+		try (Statement s = conn.createStatement()) {
+			s.execute("create table konto (id int NOT NULL auto_increment, PRIMARY KEY (id));");
+		}
+		migrate(conn, 0, targetVersion, mysql);
+		return conn;
+	}
+
+	private void migrate(Connection conn, int fromVersion, int toVersion, boolean mysql) throws SQLException {
+		for (SQLChange change : SQLChange.getChangesSinceVersion(fromVersion, mysql)) {
+			if (change.getVersion() > toVersion) {
+				continue;
+			}
+			try (Statement s = conn.createStatement()) {
+				for (String query : change.getQuery()) {
+					s.execute(query);
+				}
+			}
+		}
+	}
+
+	private BigDecimal readBack(Connection conn, String query) throws SQLException {
+		try (Statement s = conn.createStatement(); ResultSet rs = s.executeQuery(query)) {
+			assertTrue("Datensatz nicht gefunden: " + query, rs.next());
+			return rs.getBigDecimal(1);
+		}
+	}
+
+	private void assertSameValue(String column, BigDecimal expected, BigDecimal actual) {
+		assertEquals("Präzisionsverlust in " + column + ": erwartet " + expected.toPlainString()
+				+ ", gelesen " + (actual == null ? "null" : actual.toPlainString()),
+				0, expected.compareTo(actual));
+	}
+
+	private int insertUmsatz(Connection conn, BigDecimal anzahl, BigDecimal kurs, BigDecimal kosten,
+			BigDecimal gebuehren, BigDecimal steuern) throws SQLException {
+		try (PreparedStatement p = conn.prepareStatement(
+				"insert into depotviewer_umsaetze (anzahl, kurs, kursw, kosten, kostenw, "
+				+ "transaktionskosten, transaktionskostenw, steuern, steuernw, aktion, orderid) "
+				+ "values (?,?,'EUR',?,'EUR',?,'EUR',?,'EUR','KAUF','test')",
+				Statement.RETURN_GENERATED_KEYS)) {
+			p.setBigDecimal(1, anzahl);
+			p.setBigDecimal(2, kurs);
+			p.setBigDecimal(3, kosten);
+			p.setBigDecimal(4, gebuehren);
+			p.setBigDecimal(5, steuern);
+			p.executeUpdate();
+			try (ResultSet keys = p.getGeneratedKeys()) {
+				assertTrue(keys.next());
+				return keys.getInt(1);
+			}
+		}
+	}
+
+	private void checkUmsatzRoundtrip(Connection conn, BigDecimal anzahl, BigDecimal kurs,
+			BigDecimal kosten, BigDecimal gebuehren, BigDecimal steuern) throws SQLException {
+		int id = insertUmsatz(conn, anzahl, kurs, kosten, gebuehren, steuern);
+		String from = " from depotviewer_umsaetze where id = " + id;
+		assertSameValue("umsaetze.anzahl", anzahl, readBack(conn, "select anzahl" + from));
+		assertSameValue("umsaetze.kurs", kurs, readBack(conn, "select kurs" + from));
+		assertSameValue("umsaetze.kosten", kosten, readBack(conn, "select kosten" + from));
+		assertSameValue("umsaetze.transaktionskosten", gebuehren, readBack(conn, "select transaktionskosten" + from));
+		assertSameValue("umsaetze.steuern", steuern, readBack(conn, "select steuern" + from));
+	}
+
+	@Test
+	public void umsatzSpeichert8Nachkommastellen() throws Exception {
+		try (Connection conn = createDb(dbFile(), Integer.MAX_VALUE, true)) {
+			checkUmsatzRoundtrip(conn,
+					new BigDecimal("123.1234567891"),      // anzahl: decimal(20,10)
+					new BigDecimal("54321.12345678"),      // kurs
+					new BigDecimal("-98765432.12345678"),  // kosten (Kauf: negativ)
+					new BigDecimal("1.00000001"),          // transaktionskosten
+					new BigDecimal("0.12345678"));         // steuern
+		}
+	}
+
+	@Test
+	public void bestandSpeichert8Nachkommastellen() throws Exception {
+		try (Connection conn = createDb(dbFile(), Integer.MAX_VALUE, true)) {
+			BigDecimal anzahl = new BigDecimal("0.0000000001");
+			BigDecimal kurs = new BigDecimal("12345.12345678");
+			BigDecimal wert = new BigDecimal("999999999999.12345678");
+			try (PreparedStatement p = conn.prepareStatement(
+					"insert into depotviewer_bestand (anzahl, kurs, kursw, wert, wertw, datum) "
+					+ "values (?,?,'EUR',?,'EUR','2026-07-06')")) {
+				p.setBigDecimal(1, anzahl);
+				p.setBigDecimal(2, kurs);
+				p.setBigDecimal(3, wert);
+				p.executeUpdate();
+			}
+			assertSameValue("bestand.anzahl", anzahl, readBack(conn, "select anzahl from depotviewer_bestand"));
+			assertSameValue("bestand.kurs", kurs, readBack(conn, "select kurs from depotviewer_bestand"));
+			assertSameValue("bestand.wert", wert, readBack(conn, "select wert from depotviewer_bestand"));
+		}
+	}
+
+	@Test
+	public void kurseSpeichert8Nachkommastellen() throws Exception {
+		try (Connection conn = createDb(dbFile(), Integer.MAX_VALUE, true)) {
+			BigDecimal kurs = new BigDecimal("1.23456789").setScale(8, java.math.RoundingMode.HALF_UP);
+			BigDecimal kursperf = new BigDecimal("0.00000001");
+			try (PreparedStatement p = conn.prepareStatement(
+					"insert into depotviewer_kurse (wpid, kurs, kursw, kursdatum, kursperf) "
+					+ "values (1,?,'EUR','2026-07-06',?)")) {
+				p.setBigDecimal(1, kurs);
+				p.setBigDecimal(2, kursperf);
+				p.executeUpdate();
+			}
+			assertSameValue("kurse.kurs", kurs, readBack(conn, "select kurs from depotviewer_kurse"));
+			assertSameValue("kurse.kursperf", kursperf, readBack(conn, "select kursperf from depotviewer_kurse"));
+		}
+	}
+
+	@Test
+	public void kurseventSpeichert8Nachkommastellen() throws Exception {
+		try (Connection conn = createDb(dbFile(), Integer.MAX_VALUE, true)) {
+			// vor v19 nur decimal(10,5): 5 Nachkommastellen und max. 5 Vorkommastellen
+			BigDecimal dividende = new BigDecimal("123456.12345678");
+			try (PreparedStatement p = conn.prepareStatement(
+					"insert into depotviewer_kursevent (wpid, value, aktion, datum, waehrung) "
+					+ "values (1,?,'D','2026-07-06','EUR')")) {
+				p.setBigDecimal(1, dividende);
+				p.executeUpdate();
+			}
+			assertSameValue("kursevent.value", dividende, readBack(conn, "select value from depotviewer_kursevent"));
+		}
+	}
+
+	/**
+	 * Abwärtskompatibilität H2: Werte, die mit dem alten Schema (v18, decimal(20,6)
+	 * bzw. decimal(10,5)) gespeichert wurden, müssen die Migration auf v19
+	 * unverändert überstehen. Die v19-Statements laufen dabei — wie in einer
+	 * echten Hibiscus-Installation — über eine H2-Verbindung im Standardmodus.
+	 */
+	@Test
+	public void migrationV19ErhaeltBestehendeWerteH2() throws Exception {
+		File file = dbFile();
+		int umsatzId;
+		try (Connection conn = createDb(file, OLD_VERSION, false)) {
+			// Alt-Daten mit der maximalen Präzision des alten Schemas
+			umsatzId = insertUmsatz(conn,
+					new BigDecimal("10.1234567891"),
+					new BigDecimal("100.123456"),
+					new BigDecimal("-1013.123456"),
+					new BigDecimal("9.990000"),
+					new BigDecimal("3.141592"));
+			try (PreparedStatement p = conn.prepareStatement(
+					"insert into depotviewer_kursevent (wpid, value, aktion, datum, waehrung) "
+					+ "values (1,?,'D','2026-01-01','EUR')")) {
+				p.setBigDecimal(1, new BigDecimal("12345.12345"));
+				p.executeUpdate();
+			}
+		}
+
+		// v19 im H2-Standardmodus ausführen (Produktionsszenario)
+		try (Connection conn = connect(file, "")) {
+			migrate(conn, OLD_VERSION, Integer.MAX_VALUE, false);
+
+			String from = " from depotviewer_umsaetze where id = " + umsatzId;
+			assertSameValue("umsaetze.anzahl", new BigDecimal("10.1234567891"), readBack(conn, "select anzahl" + from));
+			assertSameValue("umsaetze.kurs", new BigDecimal("100.123456"), readBack(conn, "select kurs" + from));
+			assertSameValue("umsaetze.kosten", new BigDecimal("-1013.123456"), readBack(conn, "select kosten" + from));
+			assertSameValue("umsaetze.transaktionskosten", new BigDecimal("9.99"), readBack(conn, "select transaktionskosten" + from));
+			assertSameValue("umsaetze.steuern", new BigDecimal("3.141592"), readBack(conn, "select steuern" + from));
+			assertSameValue("kursevent.value", new BigDecimal("12345.12345"), readBack(conn, "select \"VALUE\" from depotviewer_kursevent"));
+
+			// Nach der Migration: volle 8 Nachkommastellen speicherbar
+			checkUmsatzRoundtrip(conn,
+					new BigDecimal("1"),
+					new BigDecimal("0.12345678"),
+					new BigDecimal("-0.12345678"),
+					new BigDecimal("0.00000001"),
+					new BigDecimal("0.99999999"));
+			try (PreparedStatement p = conn.prepareStatement(
+					"insert into depotviewer_kursevent (wpid, \"VALUE\", aktion, datum, waehrung) "
+					+ "values (2,?,'D','2026-07-06','EUR')")) {
+				p.setBigDecimal(1, new BigDecimal("0.12345678"));
+				p.executeUpdate();
+			}
+			assertSameValue("kursevent.value (8 Stellen)", new BigDecimal("0.12345678"),
+					readBack(conn, "select \"VALUE\" from depotviewer_kursevent where wpid = 2"));
+		}
+	}
+
+	/**
+	 * Gegenprobe / Dokumentation der alten Grenze: vor v19 wurden Kurse auf
+	 * 6 Nachkommastellen gerundet. Damit ist sichergestellt, dass die
+	 * Testmethodik Rundung überhaupt erkennen würde.
+	 */
+	@Test
+	public void altesSchemaRundetAuf6Nachkommastellen() throws Exception {
+		try (Connection conn = createDb(dbFile(), OLD_VERSION, true)) {
+			int id = insertUmsatz(conn,
+					new BigDecimal("1"),
+					new BigDecimal("0.12345678"), // 8 Stellen in ein decimal(20,6)-Feld
+					new BigDecimal("-1"),
+					BigDecimal.ZERO,
+					BigDecimal.ZERO);
+			BigDecimal gelesen = readBack(conn, "select kurs from depotviewer_umsaetze where id = " + id);
+			assertEquals("v18-Schema muss auf 6 Stellen runden",
+					0, new BigDecimal("0.123457").compareTo(gelesen));
+		}
+	}
+}

--- a/test/de/open4me/depot/tools/ZahlenTest.java
+++ b/test/de/open4me/depot/tools/ZahlenTest.java
@@ -1,0 +1,181 @@
+package de.open4me.depot.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import org.junit.Test;
+
+/**
+ * Sichert die Umstellung der Import-Schnittstellen von Double auf BigDecimal ab.
+ *
+ * Zwei Dinge werden geprüft:
+ * <ol>
+ * <li>Der Wertebereich, den {@link Zahlen#toBigDecimal(Object)} von fremden
+ *     Plugins entgegennimmt (die liefern historisch Double).</li>
+ * <li>Dass die synthetische OrderID exakt so berechnet wird wie vor der
+ *     Umstellung — sonst würden bereits importierte Orders doppelt angelegt.</li>
+ * </ol>
+ *
+ * Der Weg über {@code Utils.addUmsatz(...)} selbst lässt sich nicht als Unit-Test
+ * abbilden: die Methode holt die Verbindung über {@code Settings.getDBService()},
+ * und sowohl {@code Settings} als auch {@code Utils} greifen bereits beim Laden
+ * der Klasse auf die Jameica-Anwendung zu. Genau deshalb liegen die reinen
+ * Rechenregeln in {@link Zahlen}. Die Speicherpräzision der Spalten selbst deckt
+ * {@code database.PrecisionTest} auf JDBC-Ebene ab.
+ */
+public class ZahlenTest {
+
+	/**
+	 * Der Wert, an dem die alte Implementierung scheiterte: {@code new BigDecimal(double)}
+	 * expandiert die Binärdarstellung exakt, statt die dargestellte Dezimalzahl zu nehmen.
+	 */
+	private static final String KURS = "54321.12345678";
+
+	@Test
+	public void toBigDecimalNimmtBigDecimalUnveraendert() {
+		BigDecimal erwartet = new BigDecimal(KURS);
+		assertEquals(0, erwartet.compareTo(Zahlen.toBigDecimal(erwartet)));
+	}
+
+	@Test
+	public void toBigDecimalLiestStringExakt() {
+		assertEquals(0, new BigDecimal(KURS).compareTo(Zahlen.toBigDecimal(KURS)));
+	}
+
+	@Test
+	public void toBigDecimalLiefertNullFuerNull() {
+		assertNull(Zahlen.toBigDecimal(null));
+	}
+
+	/**
+	 * Fremde Plugins liefern Double. Der Wert muss der dargestellten Dezimalzahl
+	 * entsprechen und darf nicht die binaere Expansion enthalten.
+	 */
+	@Test
+	public void toBigDecimalNimmtDoubleOhneBinaerartefakte() {
+		assertEquals("0.1", Zahlen.toBigDecimal(Double.valueOf(0.1d)).toPlainString());
+		// Gegenprobe: so haette es die alte Implementierung (new BigDecimal(double)) gemacht
+		assertNotEquals("0.1", new BigDecimal(0.1d).toPlainString());
+	}
+
+	@Test
+	public void toBigDecimalNimmtGanzzahlenExakt() {
+		assertEquals(0, new BigDecimal("42").compareTo(Zahlen.toBigDecimal(Integer.valueOf(42))));
+		// Wert jenseits der exakten double-Aufloesung: ueber doubleValue() ginge er verloren
+		assertEquals(0, new BigDecimal("9007199254740993").compareTo(
+				Zahlen.toBigDecimal(Long.valueOf(9007199254740993L))));
+	}
+
+	@Test
+	public void deutscheSchreibweiseWirdExaktGelesen() {
+		assertEquals(0, new BigDecimal("1234.56").compareTo(
+				Zahlen.ausDeutscherSchreibweise("1.234,56")));
+	}
+
+	/**
+	 * Gebuehren und Steuern sind optional. Fehlen sie in der QueryMessage, muss
+	 * 0 in die Datenbank wandern und nicht NULL - so haelt es auch das Changeset
+	 * auf dbversion 12, das bestehende NULL-Werte auf 0 gesetzt hat.
+	 */
+	@Test
+	public void optionalerBetragLiefertNullStattNichts() {
+		assertEquals(0, BigDecimal.ZERO.compareTo(Zahlen.optionalerBetrag(null)));
+	}
+
+	@Test
+	public void optionalerBetragReichtVorhandeneWerteDurch() {
+		assertEquals(0, new BigDecimal("12.34").compareTo(
+				Zahlen.optionalerBetrag(Double.valueOf(12.34d))));
+	}
+
+	/**
+	 * Die OrderID muss bit-identisch zur Berechnung vor der BigDecimal-Umstellung
+	 * bleiben. Referenz ist die alte Formel mit Double-Parametern:
+	 * {@code ("" + kontoid + wpid + aktion + date + anzahl + kurs + kursW).hashCode()}
+	 */
+	@Test
+	public void orderIdBleibtKompatibelZurDoubleVariante() {
+		String kontoid = "1";
+		String wpid = "4711";
+		String aktion = "KAUF";
+		Date date = new Date(0L);
+		String kursW = "EUR";
+
+		Double altAnzahl = Double.valueOf(10.0d);
+		Double altKurs = Double.valueOf(123.45d);
+		String erwartet = "" + ("" + kontoid + wpid + aktion + date + altAnzahl + altKurs + kursW).hashCode();
+
+		String actual = Zahlen.berechneOrderId(kontoid, wpid, aktion, date,
+				new BigDecimal("10"), new BigDecimal("123.45"), kursW);
+
+		assertEquals(erwartet, actual);
+	}
+
+	/**
+	 * Gegenprobe: Ohne die doubleValue()-Umrechnung wuerde sich die OrderID aendern.
+	 * Schlaegt dieser Test fehl, ist der Kompatibilitaets-Schutz wirkungslos geworden.
+	 */
+	@Test
+	public void orderIdWuerdeSichOhneUmrechnungAendern() {
+		Date date = new Date(0L);
+		String naiv = "" + ("" + "1" + "4711" + "KAUF" + date
+				+ new BigDecimal("10") + new BigDecimal("123.45") + "EUR").hashCode();
+		String actual = Zahlen.berechneOrderId("1", "4711", "KAUF", date,
+				new BigDecimal("10"), new BigDecimal("123.45"), "EUR");
+		assertNotEquals(naiv, actual);
+	}
+
+	/**
+	 * Fehlende Werte durften frueher nicht knallen: die Verkettung mit einem
+	 * Double-Objekt ergab schlicht "null". Ein Sender, der weder orderid noch
+	 * anzahl mitschickt, muss weiterhin eine ID bekommen.
+	 */
+	@Test
+	public void orderIdVertraegtFehlendeWerte() {
+		Date date = new Date(0L);
+		Double fehlt = null;
+		String erwartet = "" + ("" + "1" + "4711" + "KAUF" + date + fehlt + fehlt + "EUR").hashCode();
+
+		assertEquals(erwartet, Zahlen.berechneOrderId("1", "4711", "KAUF", date, null, null, "EUR"));
+	}
+
+	/**
+	 * Die OrderID des Umsatz-Editors hat eine eigene Feldreihenfolge. Referenz
+	 * ist die Formel, die dort vor der BigDecimal-Umstellung stand — die Felder
+	 * lieferten damals ueber {@code DecimalInput.getValue()} ein Double.
+	 */
+	@Test
+	public void manuelleOrderIdBleibtKompatibelZurDoubleVariante() {
+		String wpid = "4711";
+		String aktion = "KAUF";
+		Date date = new Date(0L);
+
+		Double altAnzahl = Double.valueOf(10.0d);
+		Double altKurs = Double.valueOf(123.45d);
+		String erwartet = "" + (wpid + aktion + altAnzahl + altKurs + "EUR" + date).hashCode();
+
+		String actual = Zahlen.berechneManuelleOrderId(wpid, aktion,
+				new BigDecimal("10"), new BigDecimal("123.45"), "EUR", date);
+
+		assertEquals(erwartet, actual);
+	}
+
+	/**
+	 * Die beiden Formeln duerfen nicht zusammenfallen — sie unterscheiden sich
+	 * in Feldreihenfolge und Kontobezug.
+	 */
+	@Test
+	public void beideOrderIdFormelnSindVerschieden() {
+		Date date = new Date(0L);
+		BigDecimal anzahl = new BigDecimal("10");
+		BigDecimal kurs = new BigDecimal("123.45");
+
+		assertNotEquals(
+				Zahlen.berechneOrderId("1", "4711", "KAUF", date, anzahl, kurs, "EUR"),
+				Zahlen.berechneManuelleOrderId("4711", "KAUF", anzahl, kurs, "EUR", date));
+	}
+}


### PR DESCRIPTION
Betraege, Kurse, Gebuehren und Steuern werden jetzt mit decimal(20,8) gespeichert (bisher decimal(20,6), kursevent.value sogar nur decimal(10,5)).

- Changeset v19 datenbankspezifisch (H2: ALTER COLUMN, MySQL: MODIFY COLUMN), da H2 2.x kein MODIFY COLUMN mehr versteht
- Kursberechnung beim CSV-Import: Scale 5 -> 8
- Umsatz-Editor: Eingabefelder zeigen/erhalten bis zu 8 Nachkommastellen
- database.md: Analyse aller Praezisionsgrenzen in Schema, Backend und GUI
- PrecisionTest: Roundtrip-Tests (gespeichert == gelesen) und Migrationstest v18 -> v19 mit Erhalt der Altwerte (H2)